### PR TITLE
docs: add JSDoc to core abstractions and e2e examples to docs pages

### DIFF
--- a/apps/octo-docs/docs/devops/create-anchor.mdx
+++ b/apps/octo-docs/docs/devops/create-anchor.mdx
@@ -78,3 +78,69 @@ constructor(
   super(anchorId, properties, parent);
 }
 ```
+
+## Attach the anchor in a module's `onInit()`
+
+An anchor only becomes useful when it is attached to a model. Do this inside the
+module that creates and owns the parent model, using
+[`model.addAnchor()`](/api/octo/class/AModel#addAnchor).
+
+```typescript title="simple-account.module.ts"
+async onInit(inputs: SimpleAccountModuleSchema): Promise<SimpleAccount> {
+  const account = new SimpleAccount(inputs.accountId);
+
+  // Create the anchor with the properties we want to expose, and attach it.
+  account.addAnchor(
+    new SimpleAccountAnchor('SimpleAccountAnchor', { property1: inputs.property1, property2: 42 }, account),
+  );
+
+  return account;
+}
+```
+
+:::tip
+`anchorId` must be unique within the parent model.
+By convention, use the anchor class name (e.g. `'SimpleAccountAnchor'`) as the `anchorId`
+when only one anchor of that type is expected per model instance.
+:::
+
+## Consume the anchor in another module's `@Validate` schema
+
+Consuming modules declare a dependency on *a model that has this anchor*,
+rather than on the concrete model class itself.
+This keeps the two modules decoupled.
+
+```typescript title="simple-environment.module.schema.ts"
+export class SimpleEnvironmentModuleSchema extends ModuleSchema<SimpleEnvironmentModule> {
+  // Declare that we need a model carrying a SimpleAccountAnchor.
+  @Validate({
+    isModel: {
+      anchors: [{ schema: SimpleAccountAnchorSchema }],
+    },
+  })
+  account = Schema<SimpleAccount>();
+}
+```
+
+When Octo validates inputs before calling `onInit()`, it checks:
+1. The provided model has at least one anchor whose serialised form matches `SimpleAccountAnchorSchema`.
+2. The anchor's properties conform to the schema's validation rules.
+
+Inside `onInit()`, retrieve the anchor to access its exposed properties:
+
+```typescript title="simple-environment.module.ts"
+async onInit(inputs: SimpleEnvironmentModuleSchema): Promise<SimpleEnvironment> {
+  const [accountAnchor] = inputs.account.getAnchors([], [SimpleAccountAnchor]);
+
+  const environment = new SimpleEnvironment(inputs.environmentName);
+  // Use anchor properties without importing SimpleAccount directly.
+  console.log('Creating environment in account:', accountAnchor.properties.property1);
+
+  return environment;
+}
+```
+
+:::info
+See the [`AAnchor` API reference](/api/octo/class/AAnchor) for the full anchor contract,
+and the [`@Anchor` decorator reference](/api/octo/function/Anchor) for decorator options.
+:::

--- a/apps/octo-docs/docs/devops/create-model.mdx
+++ b/apps/octo-docs/docs/devops/create-model.mdx
@@ -120,6 +120,45 @@ static override async unSynth (region: SimpleRegionSchema): Promise<SimpleRegion
 }
 ```
 
+:::info[Inherited abstract methods]
+`setContext()`, `synth()`, and `unSynth()` are abstract methods inherited from
+[`AModel`](/api/octo/class/AModel).
+
+- **`setContext()`** — must return a unique string that identifies this model instance
+  across runs (e.g. `"region=us-east-1,app=my-app"`). Octo uses it for state tracking.
+- **`synth()`** — must return a plain JSON-serialisable object containing all data needed
+  to recreate the model; it is called on every run to capture the model graph state.
+- **`unSynth()`** — the static inverse of `synth()`; reconstructs a model from its
+  serialised schema. It is called when loading persisted state from the previous run.
+
+See the [`AModel` API reference](/api/octo/class/AModel) for the full contract of each method.
+:::
+
+### Parent-child registration in `onInit()`
+
+When your module creates a model that is a *child* of another model (e.g. a Region
+inside an Account), you must register the parent-child relationship inside your module's
+`onInit()` so Octo can build the correct model graph.
+
+```typescript title="aws-region.module.ts"
+async onInit(inputs: AwsRegionModuleSchema): Promise<AwsRegion> {
+  const region = new SimpleRegion(inputs.awsRegionId);
+
+  // Register the region as a child of the account model.
+  // This creates the graph edge that Octo uses for ordering and state tracking.
+  inputs.account.addChild('accountId', region, 'regionId');
+
+  return region;
+}
+```
+
+:::tip
+The first argument to `addChild()` is the field on the **parent** the child depends on,
+and the third argument is the field on the **child** that references the parent.
+These field names must match the schema property names, as Octo uses them when
+computing diffs and selecting the right model actions.
+:::
+
 ### Model Action
 In the model action, we can transform our model into a set of resources.
 In this example we will reuse the `SimpleVpc` resource we created in the previous section.

--- a/apps/octo-docs/docs/devops/create-resource.mdx
+++ b/apps/octo-docs/docs/devops/create-resource.mdx
@@ -43,6 +43,18 @@ This resource is currently empty, and we will write custom logic in these files.
 A resource schema defines the structure and validation rules for resource data,
 and will always extend from the [BaseResourceSchema](/api/octo/class/BaseResourceSchema).
 
+:::info[`properties` vs `response`]
+Every resource schema has two distinct data bags:
+
+| Field | Direction | Purpose |
+|---|---|---|
+| `properties` | **Input** — you declare these | Drive the diff and determine whether an action must run. They are set when you construct the resource inside a model action and never change unless you explicitly update them. |
+| `response` | **Output** — the cloud returns these | Written back by resource actions after a successful API call (e.g. the AWS-assigned `VpcId`). They are persisted in state and available to downstream resources. |
+
+Use `resource.setResponse(...)` inside a resource action's `handle()` to populate the response.
+See [`AResource.setResponse`](/api/octo/class/AResource) for the full API.
+:::
+
 To create a simple vpc we require certain inputs, which we will add to the property schema.
 These inputs will be passed directly to the AWS SDK, so you can add or remove inputs as per the SDK's requirements.<br/>
 For a VPC we will use the
@@ -76,6 +88,16 @@ A parent resource is a resource that is required to create this resource.
 - There are additional methods you might wish to override,
 like `diff()`, `diffInverse()`, `diffProperties()`, `diffUnpack()`, etc. from the `AResource` class.
 You can learn more about them in the API documentation of the [AResource](/api/octo/class/AResource) class.
+
+:::tip[When to override `diffProperties()`]
+The default `diffProperties()` implementation performs a deep equality check on `properties`
+and emits an `UPDATE` diff for any changed keys. Override it when a property is **immutable**
+in the cloud (e.g. a VPC CIDR block cannot be changed after creation) — in that case you
+should throw an error or emit a `REPLACE` diff so that Octo deletes and recreates the resource
+instead of attempting an in-place update.
+
+See [`AResource.diffProperties`](/api/octo/class/AResource) for the method signature.
+:::
 ```typescript title="simple-vpc.resource.ts"
 constructor(resourceId: string, properties: SimpleVpcSchema['properties'], parents: []) {
   super(resourceId, properties, parents);

--- a/apps/octo-docs/docs/fundamentals/actions.mdx
+++ b/apps/octo-docs/docs/fundamentals/actions.mdx
@@ -84,6 +84,122 @@ If an action throws an error, it immediately fails the transaction and Octo capt
 }
 ```
 
+## End-to-End Example
+
+The following walkthrough shows how a model action and a resource action chain together
+to turn a `SimpleRegion` model into a real AWS VPC.
+
+### Step 1 — Model action creates resources
+
+When Octo diffs the model graph and finds a new `SimpleRegion` node, it selects
+`AddSimpleRegionModelAction` because its `filter()` matches.
+The `handle()` method creates a `SimpleVpc` resource and returns it in `actionOutputs`.
+
+```typescript title="add-simple-region.model.action.ts"
+@Action(SimpleRegion)
+export class AddSimpleRegionModelAction implements IModelAction<SimpleRegionModule> {
+  filter(diff: Diff): boolean {
+    return (
+      diff.action === DiffAction.ADD &&
+      diff.node instanceof SimpleRegion &&
+      hasNodeName(diff.node, 'region') &&
+      diff.field === 'regionId'
+    );
+  }
+
+  async handle(
+    diff: Diff<SimpleRegion>,
+    actionInputs: EnhancedModuleSchema<SimpleRegionModule>,
+    actionOutputs: ActionOutputs,
+  ): Promise<ActionOutputs> {
+    const region = diff.node;
+
+    // Create a VPC resource for this region.
+    const vpc = new SimpleVpc(`vpc-${region.regionId}`, {
+      awsAccountId: actionInputs.inputs.account.accountId,
+      awsAvailabilityZones: [...region.awsRegionAZs],
+      awsRegionId: region.awsRegionId,
+      CidrBlock: actionInputs.inputs.vpcCidrBlock,
+      InstanceTenancy: 'default',
+    });
+
+    actionOutputs[vpc.resourceId] = vpc;
+    return actionOutputs;
+  }
+}
+```
+
+### Step 2 — Resource action calls the cloud API
+
+After all model actions complete, Octo diffs the resource graph.
+It finds the new `SimpleVpc` and selects `AddSimpleVpcResourceAction`.
+The `handle()` method calls the AWS SDK and writes the resulting VPC ID back to
+`resource.response` via `setResponse()` so that downstream resources can reference it.
+
+```typescript title="add-simple-vpc.resource.action.ts"
+@Action(SimpleVpc)
+export class AddSimpleVpcResourceAction implements IResourceAction<SimpleVpc> {
+  filter(diff: Diff): boolean {
+    return (
+      diff.action === DiffAction.ADD &&
+      diff.node instanceof SimpleVpc &&
+      hasNodeName(diff.node, 'simple-vpc') &&
+      diff.field === 'resourceId'
+    );
+  }
+
+  async handle(diff: Diff<SimpleVpc>): Promise<SimpleVpcSchema['response']> {
+    const vpc = diff.node;
+    const { awsAccountId, awsRegionId, CidrBlock, InstanceTenancy } = vpc.properties;
+
+    const ec2Client = await this.container.get<EC2Client, typeof EC2ClientFactory>(EC2Client, {
+      args: [awsAccountId, awsRegionId],
+      metadata: { package: '@octo' },
+    });
+
+    const vpcOutput = await ec2Client.send(
+      new CreateVpcCommand({ CidrBlock, InstanceTenancy }),
+    );
+
+    // Write the cloud-assigned VPC ID back onto the resource.
+    return {
+      VpcId: vpcOutput.Vpc!.VpcId!,
+      VpcArn: `arn:aws:ec2:${awsRegionId}:${awsAccountId}:vpc/${vpcOutput.Vpc!.VpcId}`,
+    };
+  }
+}
+```
+
+### How they chain
+
+```mermaid
+graph LR;
+    region((SimpleRegion <br/> model))
+    modelDiff{Model Diff}
+    modelAction{{AddSimpleRegionModelAction}}
+    vpc([SimpleVpc <br/> resource])
+    resourceDiff{Resource Diff}
+    resourceAction{{AddSimpleVpcResourceAction}}
+    aws[(AWS VPC)]
+
+    region --> modelDiff
+    modelDiff --> modelAction
+    modelAction -- "creates" --> vpc
+    vpc --> resourceDiff
+    resourceDiff --> resourceAction
+    resourceAction -- "provisions" --> aws
+```
+
+1. The **model action** transforms intent (the `SimpleRegion` model) into resources (`SimpleVpc`).
+2. The **resource action** transforms the resource definition into real cloud infrastructure.
+3. The response (`VpcId`) is written back to the resource via `setResponse()` and persisted
+   in state for the next run.
+
+:::tip
+See the [`@Action` decorator API reference](/api/octo/function/Action) for the full decorator signature,
+and the [`AResource.setResponse` API reference](/api/octo/class/AResource) for response handling details.
+:::
+
 ## Summary
 In this section we've explored Actions. This is where the "it" happens.
 Most of the logic that makes up your infrastructure will happen in these Action files.

--- a/apps/octo-docs/docs/fundamentals/anchors.mdx
+++ b/apps/octo-docs/docs/fundamentals/anchors.mdx
@@ -88,6 +88,87 @@ It exposes certain properties on the anchor, which makes up the unique signature
 Other libraries, components, or overlays can consume this anchor and will get access to the properties,
 while ensuring that the anchor is attached to a `Region` model.
 
+## End-to-End Example
+
+The following walkthrough shows the full lifecycle of an anchor:
+**define it → attach it in a module → consume it in another module**.
+
+### Step 1 — Define the anchor
+
+Create an anchor class that exposes the subset of model properties other modules need.
+
+```typescript title="aws-region.anchor.ts"
+@Anchor('@my-cdk')
+export class AwsRegionAnchor extends AAnchor<AwsRegionAnchorSchema, AwsRegion> {
+  constructor(
+    anchorId: string,
+    properties: AwsRegionAnchorSchema['properties'],
+    parent: AwsRegion,
+  ) {
+    super(anchorId, properties, parent);
+  }
+}
+```
+
+```typescript title="aws-region.anchor.schema.ts"
+export class AwsRegionAnchorSchema extends BaseAnchorSchema {
+  override properties = Schema<{
+    awsRegionId: string;
+    type: 'AWS';
+  }>();
+}
+```
+
+### Step 2 — Attach the anchor inside a module's `onInit()`
+
+In the module that owns the `AwsRegion` model, create and attach the anchor after
+constructing the model. Any module that receives this model as input can now
+discover the anchor without importing `AwsRegion` directly.
+
+```typescript title="aws-region.module.ts"
+@Module('@my-cdk', AwsRegionModuleSchema)
+export class AwsRegionModule extends AModule<AwsRegionModuleSchema, AwsRegion> {
+  async onInit(inputs: AwsRegionModuleSchema): Promise<AwsRegion> {
+    const region = new AwsRegion(inputs.awsRegionId);
+
+    // Attach the anchor so other modules can consume it.
+    region.addAnchor(
+      new AwsRegionAnchor('AwsRegionAnchor', { awsRegionId: inputs.awsRegionId, type: 'AWS' }, region),
+    );
+
+    return region;
+  }
+}
+```
+
+### Step 3 — Consume the anchor in another module's schema
+
+A consuming module declares that it needs *a model that has an `AwsRegionAnchor`*,
+rather than importing `AwsRegion` directly. This keeps the two libraries decoupled.
+
+```typescript title="aws-environment.module.schema.ts"
+export class AwsEnvironmentModuleSchema extends ModuleSchema<AwsEnvironmentModule> {
+  @Validate({
+    isModel: {
+      anchors: [{ schema: AwsRegionAnchorSchema }],
+    },
+  })
+  region = Schema<AwsRegion>();
+}
+```
+
+When Octo validates the schema it checks:
+- The supplied model has at least one anchor that serialises as `AwsRegionAnchorSchema`.
+
+This is safer than importing `AwsRegion` directly because:
+- The environment module never takes a hard dependency on the region module's internal class.
+- If the region module upgrades or renames `AwsRegion`, only the anchor schema contract matters.
+
+:::info
+See the [`@Anchor` decorator API reference](/api/octo/function/Anchor) and
+the [`AAnchor` class reference](/api/octo/class/AAnchor) for full API details.
+:::
+
 ## Summary
 In this article we discussed Anchors, who can have them, and what purpose they serve.
 Anchors make models shareable, and forms the basis of sharing information between different parts of the system.

--- a/apps/octo-docs/docs/fundamentals/overlays.mdx
+++ b/apps/octo-docs/docs/fundamentals/overlays.mdx
@@ -40,10 +40,22 @@ Instead, overlays takes *Anchors* as inputs.
 In this diagram, we have an overlay between *Model 1* and *Model 2*,
 and another overlay just on *Model 2*,
 using anchors present in both models.
-<img
-alt="overlay-and-anchor-diagram"
-src={require('./assets/overlay-introduction.png').default}
-/>
+
+```mermaid
+graph TD;
+  anchor1[\FilesystemAnchor\]
+  anchor2[\SubnetAnchor\]
+  model1((Filesystem model))
+  model2((Subnet model))
+  overlay1[FilesystemMountOverlay]
+  overlay2[SubnetSecurityOverlay]
+
+  model1 -- has --> anchor1
+  model2 -- has --> anchor2
+  overlay1 -- uses --> anchor1
+  overlay1 -- uses --> anchor2
+  overlay2 -- uses --> anchor2
+```
 
 :::info
 An overlay is not fundamentally different from a Model, but rather an extension of it.
@@ -52,6 +64,95 @@ and is managed by Octo using the same state files.
 
 Just like a model, and overlay is also considered an internal implementation.
 Overlays can also expose their own anchors as its representative.
+:::
+
+## End-to-End Example
+
+The following walkthrough shows the full lifecycle of an overlay:
+**define it → implement `diffAnchors()` → use it in a module**.
+
+### Step 1 — Define the overlay
+
+An overlay extends `AOverlay` and is decorated with `@Overlay`.
+It accepts anchors (not models) in its constructor.
+
+```typescript title="filesystem-mount.overlay.ts"
+@Overlay('@my-cdk', 'filesystem-mount', FilesystemMountOverlaySchema)
+export class FilesystemMountOverlay
+  extends AOverlay<FilesystemMountOverlaySchema, FilesystemMountOverlay>
+{
+  constructor(
+    overlayId: string,
+    properties: FilesystemMountOverlaySchema['properties'],
+    anchors: [FilesystemAnchor, SubnetAnchor],
+  ) {
+    super(overlayId, properties, anchors);
+  }
+}
+```
+
+```typescript title="filesystem-mount.overlay.schema.ts"
+export class FilesystemMountOverlaySchema extends BaseOverlaySchema {
+  override properties = Schema<{
+    mountPath: string;
+  }>();
+}
+```
+
+### Step 2 — Implement `diffAnchors()` (optional override)
+
+The base `diffAnchors()` emits an `ADD` diff for each anchor on every run.
+Override it when you need richer diff semantics — for example, to detect that a
+mount path property has changed and emit an `UPDATE` diff instead.
+
+```typescript title="filesystem-mount.overlay.ts"
+override async diffAnchors(): Promise<Diff[]> {
+  const diffs: Diff[] = [];
+
+  for (const anchor of this.getAnchors()) {
+    diffs.push(new Diff(this, DiffAction.ADD, 'anchor', anchor));
+  }
+
+  // Emit a property UPDATE diff so that update actions fire when mountPath changes.
+  // (previous state is compared by the transaction engine using the persisted schema)
+  diffs.push(new Diff(this, DiffAction.UPDATE, 'properties', { mountPath: this.properties.mountPath }));
+
+  return diffs;
+}
+```
+
+### Step 3 — Create and register the overlay in a module
+
+Inside a module's `onInit()`, retrieve the anchors from the relevant models and
+construct the overlay. The overlay is returned alongside the primary model so
+Octo tracks it in the model graph.
+
+```typescript title="filesystem-mount.module.ts"
+@Module('@my-cdk', FilesystemMountModuleSchema)
+export class FilesystemMountModule
+  extends AModule<FilesystemMountModuleSchema, FilesystemMountOverlay>
+{
+  async onInit(inputs: FilesystemMountModuleSchema): Promise<UnknownModel[]> {
+    // Retrieve anchors from previously composed modules.
+    const [filesystemAnchor] = inputs.filesystem.getAnchors([], [FilesystemAnchor]);
+    const [subnetAnchor] = inputs.subnet.getAnchors([], [SubnetAnchor]);
+
+    // Create the overlay — it automatically registers graph dependencies
+    // on both anchor parent models.
+    const overlay = new FilesystemMountOverlay(
+      `filesystem-mount-${inputs.filesystem.filesystemId}-${inputs.subnet.subnetId}`,
+      { mountPath: inputs.mountPath },
+      [filesystemAnchor as FilesystemAnchor, subnetAnchor as SubnetAnchor],
+    );
+
+    return [overlay];
+  }
+}
+```
+
+:::info
+See the [`@Overlay` decorator API reference](/api/octo/function/Overlay) and
+the [`AOverlay` class reference](/api/octo/class/AOverlay) for full API details.
 :::
 
 ## Summary

--- a/packages/octo/src/decorators/anchor.decorator.ts
+++ b/packages/octo/src/decorators/anchor.decorator.ts
@@ -13,6 +13,8 @@ import { ValidationUtility } from '../utilities/validation/validation.utility.js
  * export class MyAnchor extends AAnchor { ... }
  * ```
  * @group Decorators
+ * @param packageName The package name that owns this anchor (e.g. `'@my-package'`).
+ *   Must match the regex `^[@A-Za-z][\w-]+[A-Za-z]$`.
  * @returns The decorated class.
  * @see Definition of [Anchors](/docs/fundamentals/overlays).
  */

--- a/packages/octo/src/decorators/module.decorator.ts
+++ b/packages/octo/src/decorators/module.decorator.ts
@@ -20,6 +20,10 @@ import { ValidationUtility } from '../utilities/validation/validation.utility.js
  * }
  * ```
  * @group Decorators
+ * @param packageName The package name that owns this module (e.g. `'@my-package'`).
+ *   Must match the regex `^[@A-Za-z][\w-]+[A-Za-z]$`.
+ * @param schema The module's input schema class, used to validate inputs passed
+ *   to {@link Octo.loadModule} at registration time.
  * @returns The decorated class.
  * @see Definition of [Modules](/docs/fundamentals/modules).
  */

--- a/packages/octo/src/main.ts
+++ b/packages/octo/src/main.ts
@@ -27,6 +27,33 @@ import type { IStateProvider } from './services/state-management/state-provider.
 import { TransactionService } from './services/transaction/transaction.service.js';
 
 /**
+ * The main entry point for Octo.
+ *
+ * `Octo` orchestrates the full infrastructure lifecycle: loading modules,
+ * composing the model graph, diffing state, and executing transactions that
+ * apply (or roll back) infrastructure changes.
+ *
+ * ### Typical usage
+ * ```ts
+ * const octo = new Octo();
+ *
+ * // 1. Initialize services with a state provider.
+ * await octo.initialize(new FileSystemStateProvider('./state'));
+ *
+ * // 2. Load modules with their inputs.
+ * octo.loadModule(MyRegionModule, 'my-region', { regionId: 'us-east-1' });
+ *
+ * // 3. Set execution order and compose the model graph.
+ * octo.orderModules([['my-region']]);
+ * const { app } = await octo.compose();
+ *
+ * // 4. Lock the app and begin the transaction.
+ * const appLockId = await stateProvider.lock(app);
+ * for await (const value of octo.beginTransaction(app, { appLockId })) {
+ *   console.log('Transaction step:', value);
+ * }
+ * ```
+ *
  * @group Main
  */
 export class Octo {
@@ -43,6 +70,31 @@ export class Octo {
   private stateManagementService: StateManagementService;
   private transactionService: TransactionService;
 
+  /**
+   * Runs the full transaction pipeline for the given `app` model graph.
+   *
+   * This is an async generator that yields intermediate results at each pipeline
+   * stage. Which stages are yielded is controlled by the `yield*` options.
+   * The generator always saves state and finalises the transaction on completion.
+   *
+   * Pipeline stages (in order):
+   * 1. Model diffs — the computed {@link Diff} list for the model graph.
+   * 2. Model transaction — the batched model action executions.
+   * 3. Resource diffs — the computed diffs for the resource graph.
+   * 4. Resource transaction — the batched resource action executions.
+   *
+   * @param app The root `App` model whose graph should be transacted.
+   * @param options.appLockId The lock token obtained before calling this method.
+   *   The transaction verifies this lock before executing resource actions.
+   * @param options.enableResourceCapture When `true`, applies previously registered
+   *   capture data instead of calling the real cloud APIs.
+   * @param options.enableResourceValidation When `true`, runs validation resource actions.
+   * @param options.yieldModelDiffs Yield model diffs before executing model actions.
+   * @param options.yieldModelTransaction Yield model action results.
+   * @param options.yieldResourceDiffs Yield resource diffs before executing resource actions.
+   * @param options.yieldResourceTransaction Yield resource action results.
+   * @throws {@link TransactionError} if the app is not locked.
+   */
   async *beginTransaction(
     app: App,
     {
@@ -124,18 +176,54 @@ export class Octo {
     await this.retrieveResourceState();
   }
 
+  /**
+   * Executes all loaded modules in the order specified by {@link Octo.orderModules}
+   * and builds the model graph.
+   *
+   * Must be called after {@link Octo.initialize} and {@link Octo.orderModules},
+   * and before {@link Octo.beginTransaction}.
+   *
+   * @returns A map of module outputs keyed by `moduleId`.
+   */
   async compose(): Promise<{ [key: string]: unknown }> {
     return await this.moduleContainer.apply();
   }
 
+  /**
+   * Returns the module instance registered under the given `moduleId`.
+   *
+   * Use this after {@link Octo.compose} to inspect or interact with a specific module.
+   *
+   * @param moduleId The identifier used when the module was loaded.
+   * @returns The module instance, or `undefined` if not found.
+   */
   getModule<M extends UnknownModule>(...args: Parameters<InputService['getModule']>): M | undefined {
     return this.inputService.getModule(...args);
   }
 
+  /**
+   * Returns all resources produced by the module registered under `moduleId`.
+   *
+   * Use this after {@link Octo.compose} to inspect the resources a module created.
+   *
+   * @param moduleId The identifier used when the module was loaded.
+   * @returns The list of resources owned by that module.
+   */
   getModuleResources(...args: Parameters<InputService['getModuleResources']>): UnknownResource[] {
     return this.inputService.getModuleResources(...args);
   }
 
+  /**
+   * Initializes all Octo internal services using the provided state provider.
+   *
+   * This is the first method you must call on a new `Octo` instance.
+   * It resolves all service factories, loads any previously persisted resource
+   * state, and prepares the container for module execution.
+   *
+   * @param stateProvider The state provider used to read/write model and resource state.
+   * @param initializeInContainer Additional container entries to resolve during startup.
+   * @param excludeInContainer Factory types to unregister before startup (useful for overrides).
+   */
   async initialize(
     stateProvider: IStateProvider,
     initializeInContainer: {
@@ -184,6 +272,17 @@ export class Octo {
     await this.retrieveResourceState();
   }
 
+  /**
+   * Registers a module to be executed during {@link Octo.compose}.
+   *
+   * The `moduleId` uniquely identifies this module instance and is used to
+   * reference it in {@link Octo.orderModules}, {@link Octo.getModule}, and
+   * {@link Octo.getModuleResources}. The `inputs` must satisfy the module's schema.
+   *
+   * @param module The module class (or its registered name string) to load.
+   * @param moduleId A unique identifier for this module instance.
+   * @param inputs The validated input values for this module.
+   */
   loadModule<M extends UnknownModule>(
     module: Constructable<M> | string,
     moduleId: string,
@@ -192,24 +291,71 @@ export class Octo {
     this.moduleContainer.load(module, moduleId, inputs);
   }
 
+  /**
+   * Defines the execution order of loaded modules.
+   *
+   * Modules are executed in the order of the provided list during
+   * {@link Octo.compose}. This must be called before `compose()`.
+   *
+   * @param args Module ordering arguments forwarded to `ModuleContainer.order`.
+   */
   orderModules(...args: Parameters<ModuleContainer['order']>): ReturnType<ModuleContainer['order']> {
     this.moduleContainer.order(...args);
   }
 
+  /**
+   * Pre-registers a captured resource response for replay.
+   *
+   * When `enableResourceCapture` is `true` in {@link Octo.beginTransaction},
+   * Octo will use these captured responses instead of calling the real cloud
+   * APIs. Useful for dry-runs, tests, or replaying known state without
+   * incurring cloud costs.
+   *
+   * @param resourceContext The context string identifying the target resource.
+   * @param response The partial response to replay for that resource.
+   */
   registerCapture<S extends BaseResourceSchema>(resourceContext: string, response: Partial<S['response']>): void {
     this.captureService.registerCapture(resourceContext, response);
   }
 
+  /**
+   * Registers transaction-level lifecycle hooks.
+   *
+   * Hooks are applied globally across all modules and fire around model actions,
+   * resource actions, and commit events. Use this as an alternative to
+   * per-module {@link AModule.registerHooks} when you need cross-cutting concerns.
+   *
+   * @param args Hook registration arguments forwarded to `ModuleContainer.registerHooks`.
+   */
   registerHooks(...args: Parameters<ModuleContainer['registerHooks']>): ReturnType<ModuleContainer['registerHooks']> {
     this.moduleContainer.registerHooks(...args);
   }
 
+  /**
+   * Registers a schema translation so that a newer schema can be read as an older one (or vice versa).
+   *
+   * Use this to maintain backwards compatibility when a model or resource schema
+   * evolves across releases. The translation function maps from the old schema
+   * shape to the current one during deserialization.
+   *
+   * @param args Translation arguments forwarded to `SchemaTranslationService.registerSchemaTranslation`.
+   * @returns A handle that can be used to unregister the translation.
+   */
   registerSchemaTranslation(
     ...args: Parameters<SchemaTranslationService['registerSchemaTranslation']>
   ): ReturnType<SchemaTranslationService['registerSchemaTranslation']> {
     return this.schemaTranslationService.registerSchemaTranslation(...args);
   }
 
+  /**
+   * Registers tags to be applied to resources.
+   *
+   * Tags can be scoped to a specific module (`moduleId`), a specific resource
+   * (`resourceContext`), or applied globally when neither scope is set.
+   * Tags are merged onto matching resources before resource actions execute.
+   *
+   * @param args An array of `{ scope, tags }` entries to register.
+   */
   registerTags(
     args: { scope: { moduleId?: string; resourceContext?: string }; tags: { [key: string]: string } }[],
   ): void {

--- a/packages/octo/src/modules/module.abstract.ts
+++ b/packages/octo/src/modules/module.abstract.ts
@@ -6,7 +6,28 @@ import type { ResourceActionHook } from '../functions/hook/resource-action.hook.
 import type { IModule } from './module.interface.js';
 
 /**
+ * The abstract base class for all Octo modules.
+ *
+ * A module is the top-level unit of infrastructure work in Octo.
+ * It wraps models, overlays, resources, anchors, factories, and utilities
+ * for a single cohesive piece of infrastructure (e.g. "add an AWS region").
+ * Modules are registered with {@link Octo.loadModule} and executed in
+ * declaration order during {@link Octo.compose}.
+ *
+ * To create a custom module, extend this class and apply the {@link Module} decorator:
+ * ```ts
+ * @Module('@my-package', MyModuleSchema)
+ * export class MyModule extends AModule<MyModuleSchema, MyModel> {
+ *   async onInit(inputs: MyModuleSchema): Promise<MyModel> {
+ *     const model = new MyModel(inputs.modelId);
+ *     return model;
+ *   }
+ * }
+ * ```
+ *
  * @group Modules
+ * @see {@link Module} decorator
+ * @see [Fundamentals: Modules](/docs/fundamentals/modules)
  */
 export abstract class AModule<S, T extends UnknownModel> implements IModule<S, T> {
   static readonly MODULE_PACKAGE: string;
@@ -19,8 +40,27 @@ export abstract class AModule<S, T extends UnknownModel> implements IModule<S, T
     this.moduleId = moduleId;
   }
 
+  /**
+   * The module entry point called by Octo during {@link Octo.compose}.
+   *
+   * Implement this method to build and return the primary model (or a list of
+   * models) that this module owns. The returned model is added to the model
+   * graph and becomes the root for all resources created by this module's actions.
+   *
+   * @param inputs The validated module schema inputs supplied via {@link Octo.loadModule}.
+   * @returns The primary model, or an ordered list of models, managed by this module.
+   */
   abstract onInit(inputs: S): Promise<T | UnknownModel[]>;
 
+  /**
+   * Registers lifecycle hooks for this module.
+   *
+   * Override this method to attach pre/post hooks that run around model actions,
+   * resource actions, or commit events produced by this module.
+   * The base implementation returns an empty object (no hooks).
+   *
+   * @returns An object with optional pre/post hook arrays for each hook type.
+   */
   registerHooks(): {
     postCommitHooks?: Parameters<CommitHook['collectHooks']>[0]['postHooks'];
     postModelActionHooks?: Parameters<ModelActionHook['collectHooks']>[0]['postHooks'];
@@ -32,6 +72,16 @@ export abstract class AModule<S, T extends UnknownModel> implements IModule<S, T
     return {};
   }
 
+  /**
+   * Produces arbitrary metadata for this module.
+   *
+   * Override this method to emit key-value metadata associated with a module run
+   * (e.g. for logging, auditing, or reporting). The metadata is available to
+   * `CommitHook` consumers. The base implementation returns an empty object.
+   *
+   * @param inputs The same validated module schema inputs passed to {@link AModule.onInit}.
+   * @returns A plain key-value metadata record.
+   */
   async registerMetadata(inputs: S): Promise<Record<string, unknown>> {
     assert(!!inputs);
     return {};

--- a/packages/octo/src/overlays/anchor.abstract.ts
+++ b/packages/octo/src/overlays/anchor.abstract.ts
@@ -4,24 +4,67 @@ import type { IAnchor } from './anchor.interface.js';
 import type { BaseAnchorSchema } from './anchor.schema.js';
 
 /**
+ * The abstract base class for all Octo anchors.
+ *
+ * An anchor is a typed, serialisable representative of a model node. It exposes
+ * a subset of the model's properties so that overlays and other modules can consume
+ * them without taking a hard dependency on the concrete model class.
+ *
+ * Anchors are attached to their parent model via {@link AModel.addAnchor} and are
+ * typically created inside a module's {@link AModule.onInit} method.
+ *
+ * To create a custom anchor, extend this class and apply the {@link Anchor} decorator:
+ * ```ts
+ * @Anchor('@my-package')
+ * export class AwsRegionAnchor extends AAnchor<AwsRegionAnchorSchema, AwsRegion> {
+ *   constructor(
+ *     anchorId: string,
+ *     properties: AwsRegionAnchorSchema['properties'],
+ *     parent: AwsRegion,
+ *   ) {
+ *     super(anchorId, properties, parent);
+ *   }
+ * }
+ * ```
+ *
  * @group Overlays
+ * @see {@link Anchor} decorator
+ * @see [Fundamentals: Anchors](/docs/fundamentals/anchors)
  */
 export abstract class AAnchor<S extends BaseAnchorSchema, T extends UnknownModel> implements IAnchor<S, T> {
   /**
-   * The package of the anchor.
+   * The package name of the anchor, set by the {@link Anchor} decorator.
    */
   static readonly NODE_PACKAGE: string;
 
+  /**
+   * @param anchorId A unique identifier for this anchor instance within the parent model.
+   * @param properties The typed properties this anchor exposes to consumers.
+   * @param parent The model node that owns this anchor.
+   */
   protected constructor(
     readonly anchorId: S['anchorId'],
     readonly properties: S['properties'],
     private readonly parent: T,
   ) {}
 
+  /**
+   * Returns the model node that owns this anchor.
+   *
+   * @returns The parent model instance.
+   */
   getParent(): T {
     return this.parent;
   }
 
+  /**
+   * Serialises the anchor to a plain-object schema suitable for JSON persistence.
+   *
+   * The returned object contains `anchorId`, `properties`, and a reference to
+   * the parent model's context so that it can be re-linked during deserialization.
+   *
+   * @returns A schema object representing this anchor's current state.
+   */
   synth(): S {
     return {
       anchorId: this.anchorId,
@@ -30,6 +73,19 @@ export abstract class AAnchor<S extends BaseAnchorSchema, T extends UnknownModel
     } as S;
   }
 
+  /**
+   * Reconstructs an anchor instance from its serialised schema
+   * (the inverse of {@link AAnchor.synth}).
+   *
+   * If the anchor already exists on the parent model (by `anchorId`), its
+   * properties are updated in-place and the existing instance is returned.
+   * Otherwise a new instance is created.
+   *
+   * @param deserializationClass The concrete anchor class to instantiate.
+   * @param anchor The serialised anchor schema.
+   * @param deReferenceContext Callback to resolve the parent model by context string.
+   * @returns The reconstructed (or updated) anchor instance.
+   */
   static async unSynth(
     deserializationClass: any,
     anchor: AnchorSchema<UnknownAnchor>,


### PR DESCRIPTION
## Summary

Implements the approved documentation enhancement plan. Changes are split across two layers — JSDoc in source, and example-driven pages in the docs site.

### Source — JSDoc (`packages/octo/src`)

| File | What was added |
|---|---|
| `modules/module.abstract.ts` | Class-level JSDoc; `onInit()`, `registerHooks()`, `registerMetadata()` |
| `overlays/overlay.abstract.ts` | Class-level JSDoc; `diffAnchors()`, `diffProperties()`, `setContext()`, `synth()`, `unSynth()` |
| `overlays/anchor.abstract.ts` | Class-level JSDoc; constructor params, `getParent()`, `synth()`, `unSynth()` |
| `functions/container/container.ts` | `getInstance()`, `has()`, `copyFactories()`, `setFactories()`, `registerValue()`, `registerStartupUnhandledPromise()` (@internal), `waitToResolveAllFactories()` |
| `main.ts` | Class-level JSDoc with usage example; all 11 public methods (`beginTransaction`, `compose`, `getModule`, `getModuleResources`, `initialize`, `loadModule`, `orderModules`, `registerCapture`, `registerHooks`, `registerSchemaTranslation`, `registerTags`) |
| `decorators/anchor.decorator.ts` | Added missing `@param packageName` |
| `decorators/module.decorator.ts` | Added missing `@param packageName` and `@param schema` |

### Docs — Example-driven pages (`apps/octo-docs/docs`)

| File | What was added |
|---|---|
| `fundamentals/actions.mdx` | Complete e2e model action → resource action chain example with a Mermaid flow diagram |
| `fundamentals/anchors.mdx` | Define → attach → consume walkthrough |
| `fundamentals/overlays.mdx` | Mermaid diagram replacing static image; full define → `diffAnchors()` → use-in-module walkthrough |
| `devops/create-model.mdx` | Callout explaining `setContext()`/`synth()`/`unSynth()` contracts with API links; parent-child registration example inside `onInit()` |
| `devops/create-resource.mdx` | `properties` vs `response` callout table; `diffProperties()` override tip with API link |
| `devops/create-anchor.mdx` | Step for attaching anchor in `onInit()`; step for consuming it via `@Validate` schema in another module |

## Test plan
- [ ] No TypeScript compilation errors (`npx nx build octo`)
- [ ] No lint errors (`npx nx lint octo`)
- [ ] Docs site builds without errors (`cd apps/octo-docs && npm run build`)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily documentation/JSDoc changes with additive helper methods on `Container`; no behavioral changes to existing execution paths are apparent unless the new APIs are adopted elsewhere.
> 
> **Overview**
> **Docs:** Adds example-driven walkthroughs for **actions**, **anchors**, and **overlays** (including Mermaid diagrams), plus new guidance in the DevOps guides for attaching/consuming anchors, registering parent/child model relationships, and clarifying resource `properties` vs `response` and `diffProperties()` overrides.
> 
> **Source JSDoc:** Adds/expands JSDoc on core public APIs (`Octo`, `AModule`, `AAnchor`, `AOverlay`) and decorator parameters, and introduces documented, *additive* `Container` utilities such as `has()`, `registerValue()`, `copyFactories()/setFactories()`, and startup promise tracking to support testing and initialization sequencing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01d820e613cc2a7a8b6608b4c562423db6c8a24b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->