### PR TITLE
patch(fix): octo-aws-cdk | fix vpc schema and validate action issues.

### DIFF
--- a/.cursor/rules/workflow.mdc
+++ b/.cursor/rules/workflow.mdc
@@ -1,15 +1,13 @@
 ---
 alwaysApply: true
-description: Mandatory worktree and PR workflow for Octo
+description: PR workflow for Octo
 globs: **/*
 ---
 
 # Octo Agent Governance
 - For every request, you MUST first read the protocol in @AGENTS.md.
-- You must use worktrees for every task.
 
 # Autonomy Rules
 - You are in YOLO mode.
   Do not ask for permission to edit files or run terminal commands once the initial Plan is approved.
-- You have full permission to manage git worktrees in `../ai-worktrees/`.
-- If a command fails, self-correct and retry without prompting the user unless you are completely stuck.
+- If you are working in the `../ai-worktrees/` git worktree, you have full permission to manage that worktree.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,8 @@ Octo's documentation must grow with its feature set, with code examples, API doc
 There are pre-approved plans for many tasks under `@docs/agent-plans`.
 You must reference appropriate instructions in those plans to gain more context.
 This is also your personal note-taking space to build over time with feedbacks.
-- Use `@docs/agent-plans/validate-resource.md` to validate a resource definition in octo-aws-cdk.
+- Use `@docs/agent-plans/octo-aws-cdk-validate-resource.md` to validate a resource definition in octo-aws-cdk.
+- Use `@docs/agent-plans/octo-aws-cdk-fix-resource.md` to fix a GitHub bug issue for an octo-aws-cdk resource.
 
 ## Agent Workflow
 AI Agents must follow this workflow every time to keep the developer as hands free as possible.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,12 +55,10 @@ Octo's documentation must grow with its feature set, with code examples, API doc
     to generate API docs from JSDoc comments.
 
 ## Agent Context
-There are several AGENTS.md files scattered throughout the codebase listed below.
-You must reference appropriate instructions in those files to gain more context.
+There are pre-approved plans for many tasks under `@docs/agent-plans`.
+You must reference appropriate instructions in those plans to gain more context.
 This is also your personal note-taking space to build over time with feedbacks.
-- `@AGENTS.md`: It is this master file.
-- `@packages/octo/AGENTS.md`: Specific to base Octo library.
-- `@packages/octo-aws-cdk/AGENTS.md`: Specific to Octo AWS CDK library.
+- Use `@docs/agent-plans/validate-resource.md` to validate a resource definition in octo-aws-cdk.
 
 ## Agent Workflow
 AI Agents must follow this workflow every time to keep the developer as hands free as possible.
@@ -70,11 +68,11 @@ AI Agents must follow this workflow every time to keep the developer as hands fr
      create a git worktree: `git worktree add ../ai-worktrees/octo-worktree-<branch-name> -b ai/<branch-name>`.
      Move your execution context to that directory.
 2. **Plan**: Research the code in `@packages` and documentation in `@apps/octo-docs`.
-   Write a plan in the chat, and wait for approval.
+   Write a plan in the chat, and wait for approval. Use pre-approved plans in `@docs/agent-plans` when appropriate.
 3. **Execute**: Complete the task following the Coding Standards. Ensure all UT passes, and no linter errors.
    Once the plan is approved, do not ask for user permissions. Run in loop until the task is completed.
 4. **Feedback**: Users will provide feedback or correct your mistakes.
-   You must enhance the appropriate `@AGENTS.md` with these feedbacks so that you never make the same mistake again.
+   You must enhance the appropriate plan with these feedbacks so that you never make the same mistake again.
 5. **Submit**: Use GitHub.
    - Push the branch to origin.
    - Create a GitHub PR using guidelines in `@.github/jobs/validate-pr-title.job.sh` and with detailed description.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,15 +3,7 @@
 ## What is Octo
 Octo is a IaC tool to help developers and devops write clean infrastructure code using intent,
 rather than dealing directly with cloud resources.
-- **Models & Overlays**: Base Octo component that users can use to define infrastructure intent
-  from an application perspective. Use `@packages/octo/src/models/*`
-  to declare any infrastructure. Models help revisualize infrastructure from developer's POV.
-- **Resources**: Define a cloud resource, like a VPC, with actions on how to create, delete, update, and verify.
-- **Modules**: A CDK package that wraps models, overlays, resources, anchors, factories, and utilities for a single
-  unit of infrastructure work, such as adding a Region, or a Service. A module works on a single model,
-  but may use multiple resources.
-- **Templates**: This keeps common infrastructure patterns that users can start using now with confidence.
-  They are pre-tested e2e tests, that also serve as examples for users to cross-reference.
+Learn the fundamentals in `@apps/octo-docs/docs/fundamentals`.
 
 ## Project Structure
 Octo is a NX monorepo with 2 main directories - `apps` and `packages`.
@@ -62,15 +54,27 @@ Octo's documentation must grow with its feature set, with code examples, API doc
   - @apps/octo-docs/package.json can run `plugin:pre-script`, `plugin:build`, and `plugin:post-script`
     to generate API docs from JSDoc comments.
 
+## Agent Context
+There are several AGENTS.md files scattered throughout the codebase listed below.
+You must reference appropriate instructions in those files to gain more context.
+This is also your personal note-taking space to build over time with feedbacks.
+- `@AGENTS.md`: It is this master file.
+- `@packages/octo/AGENTS.md`: Specific to base Octo library.
+- `@packages/octo-aws-cdk/AGENTS.md`: Specific to Octo AWS CDK library.
+
 ## Agent Workflow
 AI Agents must follow this workflow every time to keep the developer as hands free as possible.
-1. **Initiate**: Create a git worktree: `git worktree add ../ai-worktrees/octo-worktree-<branch-name> -b ai/<branch-name>`.
-   Move your execution context to that directory.
-2. **Plan**: Research the code and @apps/octo-docs.
+1. **Initiate**: User might want a pair programming session or hands-free session. When in doubt, ask the user.
+   - For small refactors, stay in local context.
+   - For high autonomy tasks and large features,
+     create a git worktree: `git worktree add ../ai-worktrees/octo-worktree-<branch-name> -b ai/<branch-name>`.
+     Move your execution context to that directory.
+2. **Plan**: Research the code in `@packages` and documentation in `@apps/octo-docs`.
    Write a plan in the chat, and wait for approval.
 3. **Execute**: Complete the task following the Coding Standards. Ensure all UT passes, and no linter errors.
    Once the plan is approved, do not ask for user permissions. Run in loop until the task is completed.
-4. **Submit**: Use GitHub.
+4. **Feedback**: Users will provide feedback or correct your mistakes.
+   You must enhance the appropriate `@AGENTS.md` with these feedbacks so that you never make the same mistake again.
+5. **Submit**: Use GitHub.
    - Push the branch to origin.
-   - Create a GitHub PR with detailed description.
-5. **Notify**: Let the user know when to review the PR in the chat window.
+   - Create a GitHub PR using guidelines in `@.github/jobs/validate-pr-title.job.sh` and with detailed description.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,7 @@
 # Octo Agent Governance
 - For every request, you MUST first read the protocol in @AGENTS.md.
-- You must use worktrees for every task.
 
 # Autonomy Rules
 - You are in YOLO mode.
   Do not ask for permission to edit files or run terminal commands once the initial Plan is approved.
-- You have full permission to manage git worktrees in `../ai-worktrees/`.
-- If a command fails, self-correct and retry without prompting the user unless you are completely stuck.
+- If you are working in the `../ai-worktrees/` git worktree, you have full permission to manage that worktree.

--- a/dictionary.dic
+++ b/dictionary.dic
@@ -121,6 +121,7 @@ interop
 intra
 ip
 ipv
+ipv4
 ispec
 jpeg
 jpg

--- a/dictionary.dic
+++ b/dictionary.dic
@@ -67,6 +67,7 @@ docusaurus
 dom
 dpdm
 dualstack
+dynamodb
 ealen
 ec2
 ecma
@@ -227,6 +228,7 @@ typedoc
 udp
 un
 unicode
+unix
 unlink
 unmaintained
 unmount

--- a/docs/agent-plans/octo-aws-cdk-fix-resource.md
+++ b/docs/agent-plans/octo-aws-cdk-fix-resource.md
@@ -1,0 +1,241 @@
+# Plan: Fix an octo-aws-cdk Resource Bug (octo-aws-cdk)
+
+**Goal:** Fix a single GitHub issue by number, then open a PR.
+
+**Input:** Issue number (e.g., `19`)
+
+---
+
+## 1. Initiate
+
+### 1a. Fetch the issue
+
+```bash
+gh issue view <number> --repo quadnix/octo --json number,title,labels,body
+```
+
+Record the following fields from the issue body:
+
+| Field                 | Where in issue    |
+|-----------------------|-------------------|
+| Resource directory    | `## Resource`     |
+| Affected file(s)      | `## File`         |
+| Current (broken) code | `## Current code` |
+| Root cause            | `## Problem`      |
+| What to change        | `## Expected fix` |
+
+### 1b. Create a git worktree
+
+```bash
+git worktree add ../ai-worktrees/octo-worktree-fix-issue-<number> -b ai/fix-issue-<number>
+```
+
+Move execution context to that worktree directory for all subsequent steps.
+
+---
+
+## 2. Read Before Touching
+
+Always read every file in the resource directory before making any edit.
+
+```
+packages/octo-aws-cdk/src/resources/<name>/index.schema.ts
+packages/octo-aws-cdk/src/resources/<name>/<name>.resource.ts
+packages/octo-aws-cdk/src/resources/<name>/index.ts
+packages/octo-aws-cdk/src/resources/<name>/actions/   ← list with `ls` first, then read each file
+```
+
+Cross-reference the snippet in `## Current code` against the file you just read.
+If line numbers have shifted since the issue was filed, trust the file content — not the issue.
+
+---
+
+## 3. Identify the Fix Category
+
+Issues from the resource validation audit fall into four categories.
+Identify which one applies before editing.
+
+| Category                                 | Affected file                                | Typical issue title pattern                             |
+|------------------------------------------|----------------------------------------------|---------------------------------------------------------|
+| **A** Constructor guard missing or wrong | `{name}.resource.ts`                         | "always required", "missing guard"                      |
+| **B** Schema validation missing or wrong | `index.schema.ts`                            | "no format validation", "can be empty", "no constraint" |
+| **C** Validate action incomplete         | `actions/validate-{name}.resource.action.ts` | "does not check", "only checks length"                  |
+| **D** Error message expression wrong     | any action file                              | "masking", "misleading", "`\|\|` instead of `??`"       |
+
+---
+
+## 4. Apply the Fix
+
+### 4A. Constructor guard (`{name}.resource.ts`)
+
+Pattern: a bare `if` check fires unconditionally when it should only fire under a condition.
+
+Rules:
+
+- Wrap the existing condition with the missing guard as described in `## Expected fix`.
+- Do NOT change the error message wording unless the issue explicitly says to.
+- Keep each `if` block in the same relative position — do not reorder unrelated guards.
+- The import for `ResourceError` must already exist; do not add it if it is present.
+
+Example — issue #18 (StreamSpecification always required):
+
+```typescript
+// Before
+if (!properties.StreamSpecification) { ... }
+
+// After
+if (properties.GlobalSecondaryIndexes.length > 0 && !properties.StreamSpecification) { ... }
+```
+
+### 4B. Schema validation (`index.schema.ts`)
+
+Pattern: a `@Validate` decorator is missing a constraint, or the constraint uses the wrong option.
+
+Rules:
+
+- `@Validate` entries use a `destruct` function that returns an array of subjects, plus an `options` object.
+  The framework runs each option check against every element of the returned subjects array.
+- To validate **array minimum length** (e.g., non-empty array), do NOT spread the array into subjects.
+  Instead, return the array itself as a single element:
+  ```typescript
+  destruct: (value: ...): (string[])[] => [value.theArray],
+  options: { minLength: 1 },
+  ```
+  `validateMinLength` supports arrays natively and checks `.length`.
+- To validate a **string format**, add a `regex` option:
+  ```typescript
+  options: { regex: /^your-pattern$/ }
+  ```
+- Keep entries in the `@Validate` array in the same relative order as the surrounding entries
+  (alphabetical by the comment describing each entry is the project convention).
+- Only add a new entry to the `@Validate` array; do not restructure existing entries.
+
+### 4C. Validate action (`actions/validate-{name}.resource.action.ts`)
+
+Pattern: add one or more `if` blocks that compare live AWS state against `properties.*` or `response.*`.
+
+Rules:
+
+**Error type:** always throw `TransactionError`, never `ResourceError`.
+`TransactionError` is already imported in validate action files; do not re-import it.
+
+**Error message format:** match the pattern used by existing checks in the same file:
+
+```
+`<ResourceName> <field> mismatch. Expected: ${expected}, Actual: ${actual}`
+```
+
+**Check ordering:** place new checks after identity fields (ARN, ID) and before or after
+existing property checks, maintaining a logical reading order. Use the surrounding comments
+as placement guides.
+
+**Absent-means-default AWS fields:** some AWS fields are omitted from the response when they
+equal the service default. Treat absence as the default using `??`:
+
+```typescript
+const actualTableClass = actualTable.TableClassSummary?.TableClass ?? 'STANDARD';
+```
+
+Never throw an error when the field is absent and the default matches `properties.*`.
+
+**Array property checks:** compare each element's individual fields — not just the array length.
+A length-only check is explicitly a bug per the validate-resource audit plan.
+
+```typescript
+// Wrong — only length
+if (actual.length !== expected.length) { ... }
+
+// Correct — element-level comparison
+for (const expectedItem of expected) {
+  const actualItem = actual.find((a) => a.IndexName === expectedItem.IndexName);
+  if (!actualItem) { throw new TransactionError(`... index ${expectedItem.IndexName} not found`); }
+  if (actualItem.IndexStatus !== 'ACTIVE') { throw new TransactionError(`... index not ACTIVE`); }
+  // compare KeySchema, Projection, etc.
+}
+```
+
+**Replacing a length-only check:** if the issue asks you to replace an existing length-only
+check (e.g., issue #20 for KeySchema), remove the old `if (actualLength !== expected.length)`
+block and replace it with a per-element comparison.
+
+### 4D. Error message expression fix
+
+Pattern: `||` used where `??` is required (boolean fields coerced to string in template literals).
+
+Rules:
+
+- Replace only the exact `||` occurrences identified in the issue.
+- Do not touch any other part of the file.
+- `||` treats `false` as falsy; `??` treats only `null`/`undefined` as nullish.
+  Use `??` whenever the value can legitimately be `false` or `0`.
+
+---
+
+## 5. Quality Gates
+
+Run these checks after applying every fix, before opening the PR.
+
+### 5a. Lint
+
+```bash
+npx nx run @quadnix/octo-aws-cdk:lint
+```
+
+Zero errors, zero warnings. Fix all issues before proceeding.
+If you introduced a new word that the spell checker does not recognise, add it to `dictionary.dic`
+(one word per line, alphabetically sorted).
+
+### 5b. Unit tests
+
+```bash
+npx nx run @quadnix/octo-aws-cdk:test
+```
+
+All tests must pass. If a test was previously testing the buggy behaviour, update it to reflect
+the correct behaviour. Do not delete tests to make the suite pass.
+
+---
+
+## 6. Submit
+
+### 6a. Commit
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+patch(fix): octo-aws-cdk | <short description matching the issue title, lowercase, ends with period>.
+EOF
+)"
+```
+
+PR title must match the regex in `.github/jobs/validate-pr-title.job.sh`:
+
+```
+^(chore|major|minor|patch)\((docs|feat|fix|refactor|release|revert|test)\):\ .+\.$
+```
+
+Bug fixes use `patch(fix): octo-aws-cdk | ...`.
+The `octo-aws-cdk | ` prefix tags the commit with the package it applies to, making the git log
+easy to scan when multiple packages are changed across branches.
+
+### 6b. Push and open PR
+
+```bash
+git push -u origin ai/fix-issue-<number>
+
+gh pr create \
+  --title "patch(fix): octo-aws-cdk | <same description as commit>." \
+  --body "$(cat <<'EOF'
+## Summary
+Fixes #<number>.
+
+<One sentence: what was wrong and what was changed.>
+
+## Test plan
+- [ ] `npx nx run @quadnix/octo-aws-cdk:lint` passes with zero warnings
+- [ ] `npx nx run @quadnix/octo-aws-cdk:test` passes
+EOF
+)"
+```
+
+`Fixes #<number>` in the PR body causes GitHub to auto-close the issue on merge.

--- a/docs/agent-plans/octo-aws-cdk-validate-resource.md
+++ b/docs/agent-plans/octo-aws-cdk-validate-resource.md
@@ -1,4 +1,4 @@
-# Plan: Validate an octo-aws-cdk Resource
+# Plan: Validate an octo-aws-cdk Resource (octo-aws-cdk)
 
 **Goal:** Find and report bugs — do not fix anything. File a GitHub issue per bug at the end.
 
@@ -75,14 +75,60 @@ List `actions/` explicitly before reading so no file is missed.
 
 - Any collection where AWS requires unique names/identifiers should have a `Set`-size comparison guard.
 
-### 3d. `diffProperties()` — mutable vs. immutable
+### 3d. `diffInverse()` — clone granularity
+
+After each action completes, Octo calls `diffInverse()` on the **actual** resource to apply only the
+change that just succeeded. This is how Octo keeps the local actual state in sync with reality without
+re-querying AWS. Getting this wrong means actual can record changes as done when they haven't run yet,
+causing missed diffs on the next run.
+
+Three helpers are available (all deep-clone via `JSON.parse(JSON.stringify(...))`):
+
+| Helper                                | What it copies                                   |
+|---------------------------------------|--------------------------------------------------|
+| `cloneResourceInPlace(source, deRef)` | Everything — properties, response, tags, parents |
+| `clonePropertiesInPlace(source)`      | Only `properties`                                |
+| `cloneResponseInPlace(source)`        | Only `response`                                  |
+
+**The core rule: clone granularity must match the action granularity.**
+
+| Situation                                                                               | Correct `diffInverse` approach                                                                                                                                                                        |
+|-----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Exactly **one** update action covers **all** mutable properties                         | `cloneResourceInPlace` or `clonePropertiesInPlace` — safe because completing that one action means all properties are done                                                                            |
+| **Multiple** update actions, each covering a **different subset** of mutable properties | Surgical copy: assign only the fields that *this* action changed. Using `clonePropertiesInPlace` here is a **bug** — it would write properties belonging to sibling actions that may not have run yet |
+| Custom array diff (add/delete a single item)                                            | Push/splice only the specific item to mirror exactly what the action did in AWS                                                                                                                       |
+
+**How to audit:**
+
+1. From `diffProperties()`'s exclusion list, list every mutable property.
+2. Map each mutable property to the update action that handles it (from `diff.value.key` or custom field filter).
+3. Check `diffInverse()` in the resource class (or the lack of an override, meaning the base class runs).
+4. For every update-diff branch in `diffInverse()`, ask: *does this branch copy any property that belongs to a different
+   action?*
+   - If yes — it will prematurely commit those properties to actual. That is a **P1 bug**.
+5. Confirm `cloneResponseInPlace` is called wherever the action updates `response` fields. A missing call
+   means the new response (e.g., a new ARN after a REPLACE) is never written to actual.
+
+**Known-good examples (for reference):**
+
+- `DynamoDB.diffInverse` — calls `cloneResourceInPlace` for its single consolidated update diff.
+  Safe because only one update action exists.
+- `IamRole.diffInverse` — pushes/splices the single policy that changed.
+  Safe because each diff represents exactly one policy operation.
+- `AlbListener.diffInverse` — surgically copies `DefaultActions` or splices `rules` depending on
+  which diff branch fires. Safe because two separate update actions each own a distinct property.
+- `S3Storage.diffInverse` — copies the entire `permissions` array in one shot for the single
+  `update-permissions` action. Safe because one action handles all permission changes.
+
+### 3e. `diffProperties()` — mutable vs. immutable
 
 The exclusion list passed to `DiffUtility.isObjectDeepEquals(prev, curr, [...excluded])` declares which properties are *
 *mutable**.
 
 Check:
 
-1. Every excluded (mutable) field has a corresponding update action that handles it (see §4).
+1. Every excluded (mutable) field has a corresponding update action that handles it (see §4). This same list is the
+   input to the `diffInverse()` audit in §3d.
 2. Every non-excluded (immutable) field is actually immutable in the AWS API — and vice versa.
 3. Any additional custom immutability guards (e.g., blocking updates to existing sub-items) are correct and intentional.
 
@@ -157,7 +203,7 @@ state assumption is wrong.
   for each direction.
 - The handle method uses `diff.action` to branch correctly between add/remove/replace logic.
 - Parent resource identifiers are read from `diff.value.response.{Id}` (not from `properties`).
-- Order of operations: if a replace must delete-then-add, the delete comes first.
+- Order of operations: if a REPLACE must delete-then-add, the delete comes first.
 
 ### 4f. Tags action (`update-{name}-tags.resource.action.ts`)
 
@@ -168,11 +214,28 @@ state assumption is wrong.
 ### 4g. Validate action (`validate-{name}.resource.action.ts`)
 
 - Uses a `Describe*` command — never a mutating command.
-- Compares each **immutable** property (those not in `diffProperties()`'s exclusion list) against the AWS response.
-- Checks `response.{id/arn}` fields for identity drift.
-- Handles AWS response quirks (e.g., a field that AWS omits when it equals the default).
 - Throws `TransactionError` — not `ResourceError` — on mismatch.
 - Does not silently pass when the `Describe*` call returns nothing (check for null/undefined guards).
+
+**What must be validated — build a checklist before auditing:**
+
+1. **Response identity fields** (`response.{Id}`, `response.{Arn}`): compare every field in the response schema against the AWS describe output.
+
+2. **Every immutable property** (those *not* in `diffProperties()`'s exclusion list): compare each one fully — not just a derived metric like array length. A "length check only" on an array is a bug; the actual element values must be compared too.
+
+3. **Every mutable property that has observable AWS state** (those *in* `diffProperties()`'s exclusion list): check that the current AWS state matches `properties.*`. Common examples:
+   - Collection size (e.g., number of GSIs) — a count mismatch means out-of-band changes.
+   - Status of each element (e.g., GSI `IndexStatus === 'ACTIVE'`) — an error/deleting state would cause the next update to fail.
+   - Key shape of each element (e.g., GSI `IndexName`, `KeySchema`, `Projection`) — structural drift would corrupt future diffs.
+
+4. **AWS response quirks**: handle fields AWS omits when they equal the default (e.g., `TableClassSummary` is absent for `STANDARD`; `BillingModeSummary` is absent for `PROVISIONED`). Treat absent as the documented default — not as a mismatch.
+
+**Audit procedure:**
+
+For every property in the schema:
+- List it in a table: `property | immutable? | checked in validate?`
+- Flag any property that is unchecked or checked only partially (e.g., length instead of deep comparison).
+- For array properties: verify each element's fields are compared, not just the array length.
 
 ### 4h. `index.ts` — registration completeness
 
@@ -203,14 +266,21 @@ Severity is communicated via GitHub labels `P0`, `P1`, `P2`, `P3` — **not** in
 
 ### False-positive patterns to avoid
 
+**Empty `handle()` in a tags action (not a bug when the AWS resource does not support tagging):**
+Some AWS resource types do not support tagging at all (e.g., EFS mount targets). For those resources,
+a tags action with an empty `handle()` is intentional — it exists purely to consume tag-update diffs
+without error. Before flagging an empty tag handler, verify in the AWS API docs that the resource type
+actually supports tagging.
+
 **Optional response fields used without null guard (not a bug):**
 Response fields are typed optional because they are unpopulated before the add action runs.
 Octo guarantees the add action always completes before any subsequent action (delete, update, validate) executes,
 so those fields will always be set. Do not flag this pattern unless:
+
 - A response field is first set by an *update* action (not add), AND
 - A second update action reads that field, AND
 - There is no guaranteed run-order between the two update actions.
-Only report if all three conditions hold; frame it as a resource action run-order bug.
+  Only report if all three conditions hold; frame it as a resource action run-order bug.
 
 ### GitHub issue — one per bug
 
@@ -242,15 +312,19 @@ EOF
 )"
 ```
 
-For enhancement requests, replace `--label "bug"` with `--label "enhancement"` and change `## Expected fix` to `## Expected change`.
+For enhancement requests, replace `--label "bug"` with `--label "enhancement"` and change `## Expected fix` to
+`## Expected change`.
 
 ### Checklist before filing
 
 - [ ] `ls actions/` run — no action file skipped.
+- [ ] Validate action: built the property checklist (§4g) — every property listed, immutability noted, coverage confirmed.
+- [ ] Validate action: array properties verified element-by-element, not just by length.
 - [ ] Every `@Validate` rule verified against the AWS API docs for this service.
 - [ ] Every constructor `if` condition checked for operator-precedence traps.
 - [ ] Every `diff.value.key` string in every filter checked against current schema property names.
 - [ ] Every SDK command in every action checked for unconditional fields that depend on prior state.
 - [ ] `index.ts` checked — every action on disk is registered.
 - [ ] One issue per bug — no batching of unrelated bugs.
+- [ ] Empty tags `handle()`: verify the AWS resource type actually supports tagging before filing.
 - [ ] Optional response fields used without null guard: verify the false-positive rule above before filing.

--- a/docs/agent-plans/validate-resource.md
+++ b/docs/agent-plans/validate-resource.md
@@ -1,0 +1,256 @@
+# Plan: Validate an octo-aws-cdk Resource
+
+**Goal:** Find and report bugs — do not fix anything. File a GitHub issue per bug at the end.
+
+---
+
+## 1. Discover All Files
+
+### 1a. Locate the resource directory
+
+```
+packages/octo-aws-cdk/src/resources/{name}/
+```
+
+### 1b. Read every file in the directory — do not skip any
+
+| File                           | What to check                                          |
+|--------------------------------|--------------------------------------------------------|
+| `index.schema.ts`              | `@Validate` rules, property types, response types      |
+| `{name}.resource.ts`           | Constructor validations, `diffProperties()`            |
+| `index.ts`                     | All actions registered, exports complete               |
+| `actions/*.resource.action.ts` | Every action file — list them first with `ls actions/` |
+
+List `actions/` explicitly before reading so no file is missed.
+
+---
+
+## 2. Schema Checks (`index.schema.ts`)
+
+### 2a. For every property field in `Schema<{...}>`, verify
+
+- **String**: `minLength`? `maxLength` where AWS has a limit? `regex` where AWS restricts characters?
+- **Number**: min/max value enforced?
+- **Enum/union**: all allowed values covered and no extra values permitted?
+- **Optional field that becomes required under a condition**: `@Validate` cannot express this — flag for §3.
+- **Array**: length bounds? Each element validated via `isSchema`?
+- **Nested schema class** (`isSchema`): recursively apply the same checks to that sub-schema class.
+
+### 2b. Response fields
+
+- All fields populated by the add action are declared in the response schema.
+- No field used in any action (e.g., an ARN used in update/delete) is missing from the response schema.
+
+### 2c. Common AWS string constraint reference
+
+| Field                          | AWS rule                                    |
+|--------------------------------|---------------------------------------------|
+| Resource names (most services) | 1–255 chars, service-specific character set |
+| ARNs                           | non-empty string                            |
+| Tag keys                       | 1–128 chars                                 |
+| Tag values                     | 0–256 chars                                 |
+
+> Always verify the specific AWS docs for the service being validated — limits vary.
+
+---
+
+## 3. Resource Class Checks (`{name}.resource.ts`)
+
+### 3a. Constructor — cross-property validations
+
+`@Validate` cannot express cross-field rules. For every conditional requirement:
+
+- If field A equals X, is field B required? Verify there is an explicit check.
+- If collection C is non-empty, is field D required? Verify there is an explicit check.
+- Structural rules within arrays (e.g., key type counts, shared key constraints, projection constraints).
+
+### 3b. Array cross-reference checks
+
+- Forward: every name referenced in sub-schemas must exist in the parent definition list.
+- Backward: definition list must have no entries not referenced anywhere.
+  - When checking lengths, use `new Set(referencedNames).size` — not `.length` — to avoid false positives from
+    legitimately shared names.
+
+### 3c. Uniqueness checks
+
+- Any collection where AWS requires unique names/identifiers should have a `Set`-size comparison guard.
+
+### 3d. `diffProperties()` — mutable vs. immutable
+
+The exclusion list passed to `DiffUtility.isObjectDeepEquals(prev, curr, [...excluded])` declares which properties are *
+*mutable**.
+
+Check:
+
+1. Every excluded (mutable) field has a corresponding update action that handles it (see §4).
+2. Every non-excluded (immutable) field is actually immutable in the AWS API — and vice versa.
+3. Any additional custom immutability guards (e.g., blocking updates to existing sub-items) are correct and intentional.
+
+---
+
+## 4. Action Checks (every file in `actions/`)
+
+### 4a. Filter correctness — applies to all action types
+
+Every `filter()` method must precisely target its diff. Check:
+
+| Filter field                    | When used               | What to verify                                                                                               |
+|---------------------------------|-------------------------|--------------------------------------------------------------------------------------------------------------|
+| `diff.action`                   | All                     | `DiffAction.ADD / DELETE / UPDATE / VALIDATE` matches intent                                                 |
+| `diff.node instanceof X`        | All                     | Correct resource class                                                                                       |
+| `hasNodeName(diff.node, '...')` | All                     | Matches the second argument of `@Resource` decorator in resource file                                        |
+| `diff.field === 'resourceId'`   | add / delete / validate | Standard for lifecycle actions                                                                               |
+| `diff.field === 'properties'`   | property updates        | Used with `diff.value.key`                                                                                   |
+| `diff.value.key === '...'`      | property updates        | Must exactly match the **current** property name in the schema (case-sensitive; renames break this silently) |
+| `diff.field === 'parent'`       | parent updates          | Used with `diff.value === '<collection-name>'` or `hasNodeName(diff.value, '<parent-name>')`                 |
+| `diff.action` in parent actions | parent updates          | May cover `ADD`, `DELETE`, and `UPDATE` — check all three are handled if needed                              |
+
+### 4b. Add action (`add-{name}.resource.action.ts`)
+
+- All **required** SDK input fields are present and mapped from `properties`.
+- Conditional fields are properly guarded (e.g., field X only sent when mode is Y).
+- Optional `properties` fields that are absent are passed as `undefined` — not as empty objects or empty arrays.
+- A wait/poll is present after async creation (e.g., `waitUntilXExists`, custom polling loop).
+- The return value populates every field declared in the response schema — no missing or extra keys.
+- `mock()` builds a plausible response using only `properties` and `capture`; does not make real SDK calls.
+
+### 4c. Delete action (`delete-{name}.resource.action.ts`)
+
+- Uses the correct AWS identifier. Prefer `response.{Id/Arn}` over `properties.{name}` — names can drift.
+- If the resource requires pre-deletion steps (e.g., detach, disable protection), they are present and ordered
+  correctly.
+- A wait/poll is present if deletion is async.
+
+### 4d. Property update actions (`update-{name}*.resource.action.ts` where `diff.field === 'properties'`)
+
+These are the most bug-prone. For each:
+
+**Filter bugs:**
+
+- `diff.value.key` string must exactly match the property name in the current schema. Any rename invalidates the filter
+  silently.
+
+**Handle bugs — unconditional SDK fields:**
+The most common P0 bug. If a field is included in every SDK call regardless of prior AWS state, it may fail when the
+state assumption is wrong.
+
+- For each field in the SDK command: could sending this field cause an error if the resource was not configured that way
+  at creation?
+- Fields that enable/disable a feature (e.g., enabling/disabling streams, encryption, logging) must be sent
+  conditionally, not unconditionally.
+- If a feature can only be disabled by referencing the prior state (e.g., TTL attribute name), verify that the action
+  fetches that prior state before disabling.
+
+**Handle bugs — missing fields:**
+
+- Compare every mutable property in `diffProperties()`'s exclusion list against what the SDK command actually sends. Any
+  gap is a bug.
+
+**Handle bugs — multiple triggers:**
+
+- If the same property change triggers this action multiple times (e.g., both `billingMode` and `provisionedThroughput`
+  are mutable and both change), is the second call idempotent?
+
+### 4e. Parent update actions (`update-{name}*.resource.action.ts` where `diff.field === 'parent'`)
+
+- Filter handles all relevant `DiffAction` values (`ADD`, `DELETE`, `UPDATE`) when the AWS API requires separate calls
+  for each direction.
+- The handle method uses `diff.action` to branch correctly between add/remove/replace logic.
+- Parent resource identifiers are read from `diff.value.response.{Id}` (not from `properties`).
+- Order of operations: if a replace must delete-then-add, the delete comes first.
+
+### 4f. Tags action (`update-{name}-tags.resource.action.ts`)
+
+- The ARN passed to the tagging utility comes from `response.{ArnField}` — not from `properties`.
+- If the resource has multiple ARNs (e.g., nat-gateway with separate EIP), there is a separate tags action for each, and
+  each is registered in `index.ts`.
+
+### 4g. Validate action (`validate-{name}.resource.action.ts`)
+
+- Uses a `Describe*` command — never a mutating command.
+- Compares each **immutable** property (those not in `diffProperties()`'s exclusion list) against the AWS response.
+- Checks `response.{id/arn}` fields for identity drift.
+- Handles AWS response quirks (e.g., a field that AWS omits when it equals the default).
+- Throws `TransactionError` — not `ResourceError` — on mismatch.
+- Does not silently pass when the `Describe*` call returns nothing (check for null/undefined guards).
+
+### 4h. `index.ts` — registration completeness
+
+- Every action factory listed above is imported and registered.
+- The resource class and schema are exported.
+- No action file exists on disk that is not imported in `index.ts`.
+
+---
+
+## 5. Reporting Bugs
+
+### Severity classification
+
+| Severity | Meaning                                                        |
+|----------|----------------------------------------------------------------|
+| **P0**   | AWS SDK call fails; resource cannot be created/updated/deleted |
+| **P1**   | SDK call succeeds but resource is silently misconfigured       |
+| **P2**   | Valid input rejected by an overly strict validation            |
+| **P3**   | Edge case gap; unlikely to hit in normal use                   |
+
+Severity is communicated via GitHub labels `P0`, `P1`, `P2`, `P3` — **not** in the issue title or body.
+
+### Bug vs. enhancement
+
+- If a property's allowed values are intentionally restricted by the current implementation (not an AWS limitation),
+  that is an **enhancement request**, not a bug. Use `--label "enhancement"` instead of `--label "bug"`.
+- If the AWS API itself imposes a stricter constraint than the schema, that is a bug.
+
+### False-positive patterns to avoid
+
+**Optional response fields used without null guard (not a bug):**
+Response fields are typed optional because they are unpopulated before the add action runs.
+Octo guarantees the add action always completes before any subsequent action (delete, update, validate) executes,
+so those fields will always be set. Do not flag this pattern unless:
+- A response field is first set by an *update* action (not add), AND
+- A second update action reads that field, AND
+- There is no guaranteed run-order between the two update actions.
+Only report if all three conditions hold; frame it as a resource action run-order bug.
+
+### GitHub issue — one per bug
+
+```bash
+gh issue create \
+  --repo quadnix/octo \
+  --title "<ResourceName>: <short description>" \
+  --label "bug" \
+  --label "octo-aws-cdk" \
+  --label "P<n>" \
+  --body "$(cat <<'EOF'
+## Resource
+`packages/octo-aws-cdk/src/resources/<name>/`
+
+## File
+`<relative path>`, line <N>
+
+## Current code
+\`\`\`typescript
+<paste offending snippet>
+\`\`\`
+
+## Problem
+<one or two sentences: what fails and why>
+
+## Expected fix
+<one or two sentences: what the correct behaviour should be>
+EOF
+)"
+```
+
+For enhancement requests, replace `--label "bug"` with `--label "enhancement"` and change `## Expected fix` to `## Expected change`.
+
+### Checklist before filing
+
+- [ ] `ls actions/` run — no action file skipped.
+- [ ] Every `@Validate` rule verified against the AWS API docs for this service.
+- [ ] Every constructor `if` condition checked for operator-precedence traps.
+- [ ] Every `diff.value.key` string in every filter checked against current schema property names.
+- [ ] Every SDK command in every action checked for unconditional fields that depend on prior state.
+- [ ] `index.ts` checked — every action on disk is registered.
+- [ ] One issue per bug — no batching of unrelated bugs.
+- [ ] Optional response fields used without null guard: verify the false-positive rule above before filing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4538,6 +4538,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -6072,12 +6084,12 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.5.tgz",
-      "integrity": "sha512-jcrqdTQurIrBbUm4W2YdLVMQDoL0sA9DTxYd2s+R/y+2U9NLOP7Xf/YqfSg1FZhlZIYEnvk2mwbyvIfdLEPo8g==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.8.tgz",
+      "integrity": "sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6110,15 +6122,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.5.tgz",
-      "integrity": "sha512-viuHMxBAqydkB0AfWwHIdwf/PRH2z5KHGUzqyRtS/Wv+n3IHI993Sk76VCA7dD/+GzgGOmlJDITfPcJC1nIVIw==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.6.tgz",
+      "integrity": "sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.4",
-        "@smithy/types": "^4.3.2",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6126,50 +6139,36 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.8.0.tgz",
-      "integrity": "sha512-EYqsIYJmkR1VhVE9pccnk353xhs+lB6btdutJEtsp7R055haMJp2yE16eSxw8fv+G0WUY6vqxyYOP8kOqawxYQ==",
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.2.tgz",
+      "integrity": "sha512-HaaH4VbGie4t0+9nY3tNBRSxVTr96wzIqexUa6C2qx3MPePAuz7lIxPxYtt1Wc//SPfJLNoZJzfdt0B6ksj2jA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.0.9",
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/types": "^4.3.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.5",
-        "@smithy/util-stream": "^4.2.4",
-        "@smithy/util-utf8": "^4.0.0",
-        "@types/uuid": "^9.0.1",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-stream": "^4.5.12",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/core/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.7.tgz",
-      "integrity": "sha512-dDzrMXA8d8riFNiPvytxn0mNwR4B3h8lgrQ5UjAGu6T9z/kRg/Xncf4tEQHE/+t25sY8IH3CowcmWi+1U5B1Gw==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.8.tgz",
+      "integrity": "sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.4",
-        "@smithy/property-provider": "^4.0.5",
-        "@smithy/types": "^4.3.2",
-        "@smithy/url-parser": "^4.0.5",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6247,15 +6246,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.1.tgz",
-      "integrity": "sha512-61WjM0PWmZJR+SnmzaKI7t7G0UkkNFboDpzIdzSoy7TByUzlxo18Qlh9s71qug4AY4hlH/CwXdubMtkcNEb/sQ==",
+      "version": "5.3.9",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.9.tgz",
+      "integrity": "sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/querystring-builder": "^4.0.5",
-        "@smithy/types": "^4.3.2",
-        "@smithy/util-base64": "^4.0.0",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/querystring-builder": "^4.2.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-base64": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6278,14 +6277,14 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.5.tgz",
-      "integrity": "sha512-cv1HHkKhpyRb6ahD8Vcfb2Hgz67vNIXEp2vnhzfxLFGRukLCNEA5QdsorbUEzXma1Rco0u3rx5VTqbM06GcZqQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.8.tgz",
+      "integrity": "sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6307,12 +6306,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.5.tgz",
-      "integrity": "sha512-IVnb78Qtf7EJpoEVo7qJ8BEXQwgC4n3igeJNNKEj/MLYtapnx8A67Zt/J3RXAj2xSO1910zk0LdFiygSemuLow==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.8.tgz",
+      "integrity": "sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6320,9 +6319,9 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
-      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6346,13 +6345,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.5.tgz",
-      "integrity": "sha512-l1jlNZoYzoCC7p0zCtBDE5OBXZ95yMKlRlftooE5jPWQn4YBPLgsp+oeHp7iMHaTGoUdFqmHOPa8c9G3gBsRpQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.8.tgz",
+      "integrity": "sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/types": "^4.3.2",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6360,18 +6359,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.18.tgz",
-      "integrity": "sha512-ZhvqcVRPZxnZlokcPaTwb+r+h4yOIOCJmx0v2d1bpVlmP465g3qpVSf7wxcq5zZdu4jb0H4yIMxuPwDJSQc3MQ==",
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.16.tgz",
+      "integrity": "sha512-L5GICFCSsNhbJ5JSKeWFGFy16Q2OhoBizb3X2DrxaJwXSEujVvjG9Jt386dpQn2t7jINglQl0b4K/Su69BdbMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.8.0",
-        "@smithy/middleware-serde": "^4.0.9",
-        "@smithy/node-config-provider": "^4.1.4",
-        "@smithy/shared-ini-file-loader": "^4.0.5",
-        "@smithy/types": "^4.3.2",
-        "@smithy/url-parser": "^4.0.5",
-        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/core": "^3.23.2",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-middleware": "^4.2.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6379,47 +6378,33 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.1.19",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.19.tgz",
-      "integrity": "sha512-X58zx/NVECjeuUB6A8HBu4bhx72EoUz+T5jTMIyeNKx2lf+Gs9TmWPNNkH+5QF0COjpInP/xSpJGJ7xEnAklQQ==",
+      "version": "4.4.33",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.33.tgz",
+      "integrity": "sha512-jLqZOdJhtIL4lnA9hXnAG6GgnJlo1sD3FqsTxm9wSfjviqgWesY/TMBVnT84yr4O0Vfe0jWoXlfFbzsBVph3WA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.4",
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/service-error-classification": "^4.0.7",
-        "@smithy/smithy-client": "^4.4.10",
-        "@smithy/types": "^4.3.2",
-        "@smithy/util-middleware": "^4.0.5",
-        "@smithy/util-retry": "^4.0.7",
-        "@types/uuid": "^9.0.1",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/service-error-classification": "^4.2.8",
+        "@smithy/smithy-client": "^4.11.5",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.9.tgz",
-      "integrity": "sha512-uAFFR4dpeoJPGz8x9mhxp+RPjo5wW0QEEIPPPbLXiRRWeCATf/Km3gKIVR5vaP8bN1kgsPhcEeh+IZvUlBv6Xg==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.9.tgz",
+      "integrity": "sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/types": "^4.3.2",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6427,12 +6412,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.5.tgz",
-      "integrity": "sha512-/yoHDXZPh3ocRVyeWQFvC44u8seu3eYzZRveCMfgMOBcNKnAmOvjbL9+Cp5XKSIi9iYA9PECUuW2teDAk8T+OQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.8.tgz",
+      "integrity": "sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6440,14 +6425,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.4.tgz",
-      "integrity": "sha512-+UDQV/k42jLEPPHSn39l0Bmc4sB1xtdI9Gd47fzo/0PbXzJ7ylgaOByVjF5EeQIumkepnrJyfx86dPa9p47Y+w==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.8.tgz",
+      "integrity": "sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.5",
-        "@smithy/shared-ini-file-loader": "^4.0.5",
-        "@smithy/types": "^4.3.2",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6455,15 +6440,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.1.tgz",
-      "integrity": "sha512-RHnlHqFpoVdjSPPiYy/t40Zovf3BBHc2oemgD7VsVTFFZrU5erFFe0n52OANZZ/5sbshgD93sOh5r6I35Xmpaw==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.10.tgz",
+      "integrity": "sha512-u4YeUwOWRZaHbWaebvrs3UhwQwj+2VNmcVCwXcYTvPIuVyM7Ex1ftAj+fdbG/P4AkBwLq/+SKn+ydOI4ZJE9PA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.5",
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/querystring-builder": "^4.0.5",
-        "@smithy/types": "^4.3.2",
+        "@smithy/abort-controller": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/querystring-builder": "^4.2.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6471,12 +6456,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.5.tgz",
-      "integrity": "sha512-R/bswf59T/n9ZgfgUICAZoWYKBHcsVDurAGX88zsiUtOTA/xUAPyiT+qkNCPwFn43pZqN84M4MiUsbSGQmgFIQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.8.tgz",
+      "integrity": "sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6484,12 +6469,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
-      "integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.8.tgz",
+      "integrity": "sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6497,13 +6482,13 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.5.tgz",
-      "integrity": "sha512-NJeSCU57piZ56c+/wY+AbAw6rxCCAOZLCIniRE7wqvndqxcKKDOXzwWjrY7wGKEISfhL9gBbAaWWgHsUGedk+A==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.8.tgz",
+      "integrity": "sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2",
-        "@smithy/util-uri-escape": "^4.0.0",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-uri-escape": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6511,12 +6496,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.5.tgz",
-      "integrity": "sha512-6SV7md2CzNG/WUeTjVe6Dj8noH32r4MnUeFKZrnVYsQxpGSIcphAanQMayi8jJLZAWm6pdM9ZXvKCpWOsIGg0w==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.8.tgz",
+      "integrity": "sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6524,24 +6509,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.7.tgz",
-      "integrity": "sha512-XvRHOipqpwNhEjDf2L5gJowZEm5nsxC16pAZOeEcsygdjv9A2jdOh3YoDQvOXBGTsaJk6mNWtzWalOB9976Wlg==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.8.tgz",
+      "integrity": "sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2"
+        "@smithy/types": "^4.12.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.5.tgz",
-      "integrity": "sha512-YVVwehRDuehgoXdEL4r1tAAzdaDgaC9EQvhK0lEbfnbrd0bd5+CTQumbdPryX3J2shT7ZqQE+jPW4lmNBAB8JQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.3.tgz",
+      "integrity": "sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6549,18 +6534,18 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.3.tgz",
-      "integrity": "sha512-mARDSXSEgllNzMw6N+mC+r1AQlEBO3meEAkR/UlfAgnMzJUB3goRBWgip1EAMG99wh36MDqzo86SfIX5Y+VEaw==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.8.tgz",
+      "integrity": "sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/types": "^4.3.2",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.5",
-        "@smithy/util-uri-escape": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6568,17 +6553,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.10.tgz",
-      "integrity": "sha512-iW6HjXqN0oPtRS0NK/zzZ4zZeGESIFcxj2FkWed3mcK8jdSdHzvnCKXSjvewESKAgGKAbJRA+OsaqKhkdYRbQQ==",
+      "version": "4.11.5",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.11.5.tgz",
+      "integrity": "sha512-xixwBRqoeP2IUgcAl3U9dvJXc+qJum4lzo3maaJxifsZxKUYLfVfCXvhT4/jD01sRrHg5zjd1cw2Zmjr4/SuKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.8.0",
-        "@smithy/middleware-endpoint": "^4.1.18",
-        "@smithy/middleware-stack": "^4.0.5",
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/types": "^4.3.2",
-        "@smithy/util-stream": "^4.2.4",
+        "@smithy/core": "^3.23.2",
+        "@smithy/middleware-endpoint": "^4.4.16",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-stream": "^4.5.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6586,9 +6571,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
-      "integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
+      "integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6598,13 +6583,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.5.tgz",
-      "integrity": "sha512-j+733Um7f1/DXjYhCbvNXABV53NyCRRA54C7bNEIxNPs0YjfRxeMKjjgm2jvTYrciZyCjsicHwQ6Q0ylo+NAUw==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.8.tgz",
+      "integrity": "sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.0.5",
-        "@smithy/types": "^4.3.2",
+        "@smithy/querystring-parser": "^4.2.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6612,13 +6597,13 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
-      "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6626,9 +6611,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
-      "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6638,9 +6623,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
-      "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6650,12 +6635,12 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
-      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/is-array-buffer": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6663,9 +6648,9 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
-      "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6675,15 +6660,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.26",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.26.tgz",
-      "integrity": "sha512-xgl75aHIS/3rrGp7iTxQAOELYeyiwBu+eEgAk4xfKwJJ0L8VUjhO2shsDpeil54BOFsqmk5xfdesiewbUY5tKQ==",
+      "version": "4.3.32",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.32.tgz",
+      "integrity": "sha512-092sjYfFMQ/iaPH798LY/OJFBcYu0sSK34Oy9vdixhsU36zlZu8OcYjF3TD4e2ARupyK7xaxPXl+T0VIJTEkkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.5",
-        "@smithy/smithy-client": "^4.4.10",
-        "@smithy/types": "^4.3.2",
-        "bowser": "^2.11.0",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/smithy-client": "^4.11.5",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6691,17 +6675,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.26",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.26.tgz",
-      "integrity": "sha512-z81yyIkGiLLYVDetKTUeCZQ8x20EEzvQjrqJtb/mXnevLq2+w3XCEWTJ2pMp401b6BkEkHVfXb/cROBpVauLMQ==",
+      "version": "4.2.35",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.35.tgz",
+      "integrity": "sha512-miz/ggz87M8VuM29y7jJZMYkn7+IErM5p5UgKIf8OtqVs/h2bXr1Bt3uTsREsI/4nK8a0PQERbAPsVPVNIsG7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.1.5",
-        "@smithy/credential-provider-imds": "^4.0.7",
-        "@smithy/node-config-provider": "^4.1.4",
-        "@smithy/property-provider": "^4.0.5",
-        "@smithy/smithy-client": "^4.4.10",
-        "@smithy/types": "^4.3.2",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/credential-provider-imds": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/smithy-client": "^4.11.5",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6709,13 +6693,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.7.tgz",
-      "integrity": "sha512-klGBP+RpBp6V5JbrY2C/VKnHXn3d5V2YrifZbmMY8os7M6m8wdYFoO6w/fe5VkP+YVwrEktW3IWYaSQVNZJ8oQ==",
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.8.tgz",
+      "integrity": "sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.4",
-        "@smithy/types": "^4.3.2",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6723,9 +6707,9 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
-      "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6735,12 +6719,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.5.tgz",
-      "integrity": "sha512-N40PfqsZHRSsByGB81HhSo+uvMxEHT+9e255S53pfBw/wI6WKDI7Jw9oyu5tJTLwZzV5DsMha3ji8jk9dsHmQQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.8.tgz",
+      "integrity": "sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6748,13 +6732,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.7.tgz",
-      "integrity": "sha512-TTO6rt0ppK70alZpkjwy+3nQlTiqNfoXja+qwuAchIEAIoSZW8Qyd76dvBv3I5bCpE38APafG23Y/u270NspiQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.8.tgz",
+      "integrity": "sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.0.7",
-        "@smithy/types": "^4.3.2",
+        "@smithy/service-error-classification": "^4.2.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6762,18 +6746,18 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.4.tgz",
-      "integrity": "sha512-vSKnvNZX2BXzl0U2RgCLOwWaAP9x/ddd/XobPK02pCbzRm5s55M53uwb1rl/Ts7RXZvdJZerPkA+en2FDghLuQ==",
+      "version": "4.5.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.12.tgz",
+      "integrity": "sha512-D8tgkrmhAX/UNeCZbqbEO3uqyghUnEmmoO9YEvRuwxjlkKKUE7FOgCJnqpTlQPe9MApdWPky58mNQQHbnCzoNg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.1.1",
-        "@smithy/node-http-handler": "^4.1.1",
-        "@smithy/types": "^4.3.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/node-http-handler": "^4.4.10",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6781,9 +6765,9 @@
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
-      "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6793,12 +6777,12 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
-      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-buffer-from": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6806,13 +6790,25 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.0.7.tgz",
-      "integrity": "sha512-mYqtQXPmrwvUljaHyGxYUIIRI3qjBTEb/f5QFi3A6VlxhpmZd5mWXn9W+qUkf2pVE1Hv3SqxefiZOPGdxmO64A==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.8.tgz",
+      "integrity": "sha512-n+lahlMWk+aejGuax7DPWtqav8HYnWxQwR+LCG2BgCUmaGcTe9qZCFsmw8TMg9iG75HOwhrJCX9TCJRLH+Yzqg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.5",
-        "@smithy/types": "^4.3.2",
+        "@smithy/abort-controller": "^4.2.8",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
+      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6968,6 +6964,30 @@
       "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-3.1.5.tgz",
       "integrity": "sha512-nv+GSx77ZtXiJzwKdsASqi+YQ5Z7vwHsTP0JY2SiQgjGckkBRKZnk8nIM+7oUZ1VCtuTz0+By4qVR7fqzp/Dfg==",
       "license": "MIT"
+    },
+    "node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -7728,6 +7748,198 @@
         "win32"
       ]
     },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
+    },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
@@ -8222,6 +8434,20 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-import-phases": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "acorn": "^8.14.0"
+      }
+    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -8293,6 +8519,51 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -9634,6 +9905,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/ci-info": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
@@ -9860,6 +10142,14 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/common-ancestor-path": {
       "version": "1.0.1",
@@ -11067,6 +11357,14 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -12615,6 +12913,14 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/glob/node_modules/minimatch": {
       "version": "10.0.3",
@@ -15019,6 +15325,21 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/loader-runner": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -15597,6 +15918,15 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -16272,6 +16602,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
@@ -17299,6 +17635,17 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -17942,6 +18289,67 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/schema-utils/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
@@ -17958,6 +18366,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
       }
     },
     "node_modules/set-function-length": {
@@ -18928,6 +19347,95 @@
         "streamx": "^2.12.5"
       }
     },
+    "node_modules/terser": {
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
+      "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser-webpack-plugin": {
+      "version": "5.3.16",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
+      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "serialize-javascript": "^6.0.2",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -19886,6 +20394,21 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/watchpack": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -19893,6 +20416,93 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webpack": {
+      "version": "5.105.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
+      "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.8",
+        "@types/json-schema": "^7.0.15",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.15.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.28.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.19.0",
+        "es-module-lexer": "^2.0.0",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.3.1",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.3.16",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.3.3"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
+      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/webpack/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/which": {
@@ -21101,6 +21711,7 @@
       "name": "@quadnix/octo-aws-cdk",
       "version": "0.0.19",
       "dependencies": {
+        "@aws-sdk/client-dynamodb": "~3.743.0",
         "@aws-sdk/client-ec2": "~3.743.0",
         "@aws-sdk/client-ecr": "~3.743.0",
         "@aws-sdk/client-ecs": "~3.743.0",
@@ -21120,6 +21731,103 @@
       "devDependencies": {},
       "engines": {
         "node": ">=18.18.0"
+      }
+    },
+    "packages/octo-aws-cdk/node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.743.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.743.0.tgz",
+      "integrity": "sha512-qt+RfnHqhPyRMb4O99FgME+/I3S0r0028pLe59yse08P5ZrTAIZQbpwDGAcvLN2dICd4oh18+Y7iLej9GPBRBQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.734.0",
+        "@aws-sdk/credential-provider-node": "3.743.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.734.0",
+        "@aws-sdk/middleware-host-header": "3.734.0",
+        "@aws-sdk/middleware-logger": "3.734.0",
+        "@aws-sdk/middleware-recursion-detection": "3.734.0",
+        "@aws-sdk/middleware-user-agent": "3.743.0",
+        "@aws-sdk/region-config-resolver": "3.734.0",
+        "@aws-sdk/types": "3.734.0",
+        "@aws-sdk/util-endpoints": "3.743.0",
+        "@aws-sdk/util-user-agent-browser": "3.734.0",
+        "@aws-sdk/util-user-agent-node": "3.743.0",
+        "@smithy/config-resolver": "^4.0.1",
+        "@smithy/core": "^3.1.1",
+        "@smithy/fetch-http-handler": "^5.0.1",
+        "@smithy/hash-node": "^4.0.1",
+        "@smithy/invalid-dependency": "^4.0.1",
+        "@smithy/middleware-content-length": "^4.0.1",
+        "@smithy/middleware-endpoint": "^4.0.2",
+        "@smithy/middleware-retry": "^4.0.3",
+        "@smithy/middleware-serde": "^4.0.1",
+        "@smithy/middleware-stack": "^4.0.1",
+        "@smithy/node-config-provider": "^4.0.1",
+        "@smithy/node-http-handler": "^4.0.2",
+        "@smithy/protocol-http": "^5.0.1",
+        "@smithy/smithy-client": "^4.1.2",
+        "@smithy/types": "^4.1.0",
+        "@smithy/url-parser": "^4.0.1",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.3",
+        "@smithy/util-defaults-mode-node": "^4.0.3",
+        "@smithy/util-endpoints": "^3.0.1",
+        "@smithy/util-middleware": "^4.0.1",
+        "@smithy/util-retry": "^4.0.1",
+        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-waiter": "^4.0.2",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/octo-aws-cdk/node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.723.0.tgz",
+      "integrity": "sha512-2+a4WXRc+07uiPR+zJiPGKSOWaNJQNqitkks+6Hhm/haTLJqNVTgY2OWDh2PXvwMNpKB+AlGdhE65Oy6NzUgXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/octo-aws-cdk/node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.734.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.734.0.tgz",
+      "integrity": "sha512-hE3x9Sbqy64g/lcFIq7BF9IS1tSOyfBCyHf1xBgevWeFIDTWh647URuCNWoEwtw4HMEhO2MDUQcKf1PFh1dNDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "3.723.0",
+        "@aws-sdk/types": "3.734.0",
+        "@smithy/node-config-provider": "^4.0.1",
+        "@smithy/protocol-http": "^5.0.1",
+        "@smithy/types": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/octo-aws-cdk/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "packages/octo-build": {

--- a/packages/octo-aws-cdk/package.json
+++ b/packages/octo-aws-cdk/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "~3.743.0",
     "@aws-sdk/client-ec2": "~3.743.0",
     "@aws-sdk/client-ecr": "~3.743.0",
     "@aws-sdk/client-ecs": "~3.743.0",
@@ -74,6 +75,7 @@
     "./resources/alb-listener/schema": "./dist/resources/alb-listener/index.schema.js",
     "./resources/alb-target-group/schema": "./dist/resources/alb-target-group/index.schema.js",
     "./resources/alb/schema": "./dist/resources/alb/index.schema.js",
+    "./resources/dynamodb/schema": "./dist/resources/dynamodb/index.schema.js",
     "./resources/ecr/schema": "./dist/resources/ecr/index.schema.js",
     "./resources/ecs-cluster/schema": "./dist/resources/ecs-cluster/index.schema.js",
     "./resources/ecs-service/schema": "./dist/resources/ecs-service/index.schema.js",

--- a/packages/octo-aws-cdk/src/factories/aws-client.factory.ts
+++ b/packages/octo-aws-cdk/src/factories/aws-client.factory.ts
@@ -1,3 +1,4 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { EC2Client } from '@aws-sdk/client-ec2';
 import { ECRClient } from '@aws-sdk/client-ecr';
 import { ECSClient } from '@aws-sdk/client-ecs';
@@ -63,6 +64,20 @@ class AwsClientFactory {
       'Method not implemented! Use derived class implementation',
       AwsClientFactory.name,
     );
+  }
+}
+
+/**
+ * @internal
+ */
+@Factory<DynamoDBClient>(DynamoDBClient, { metadata: { package: '@octo' } })
+export class DynamoDBClientFactory extends AwsClientFactory {
+  static override createInstance(
+    awsRegionId: string,
+    credentials: AwsCredentialIdentityProvider,
+    endpointInputConfig: EndpointInputConfig = {},
+  ): DynamoDBClient {
+    return new DynamoDBClient({ ...credentials, ...endpointInputConfig, region: awsRegionId });
   }
 }
 

--- a/packages/octo-aws-cdk/src/resources/dynamodb/actions/add-dynamodb.resource.action.ts
+++ b/packages/octo-aws-cdk/src/resources/dynamodb/actions/add-dynamodb.resource.action.ts
@@ -1,0 +1,125 @@
+import {
+  CreateTableCommand,
+  DynamoDBClient,
+  UpdateTimeToLiveCommand,
+  waitUntilTableExists,
+} from '@aws-sdk/client-dynamodb';
+import { ANodeAction, Action, type Diff, DiffAction, Factory, type IResourceAction, hasNodeName } from '@quadnix/octo';
+import { DynamoDBClientFactory } from '../../../factories/aws-client.factory.js';
+import { DynamoDB } from '../dynamodb.resource.js';
+import type { DynamoDBSchema } from '../index.schema.js';
+
+/**
+ * @internal
+ */
+@Action(DynamoDB)
+export class AddDynamoDBResourceAction extends ANodeAction implements IResourceAction<DynamoDB> {
+  constructor() {
+    super();
+  }
+
+  filter(diff: Diff): boolean {
+    return (
+      diff.action === DiffAction.ADD &&
+      diff.node instanceof DynamoDB &&
+      hasNodeName(diff.node, 'dynamodb') &&
+      diff.field === 'resourceId'
+    );
+  }
+
+  async handle(diff: Diff<DynamoDB>): Promise<DynamoDBSchema['response']> {
+    // Get properties.
+    const dynamoDB = diff.node;
+    const properties = dynamoDB.properties;
+    const tags = dynamoDB.tags;
+
+    // Get instances.
+    const dynamoDBClient = await this.container.get<DynamoDBClient, typeof DynamoDBClientFactory>(DynamoDBClient, {
+      args: [properties.awsAccountId, properties.awsRegionId],
+      metadata: { package: '@octo' },
+    });
+
+    // Create DynamoDB table.
+    const createTableCommandOutput = await dynamoDBClient.send(
+      new CreateTableCommand({
+        AttributeDefinitions: properties.AttributeDefinitions,
+        BillingMode: properties.billingMode.type,
+        DeletionProtectionEnabled: properties.DeletionProtectionEnabled,
+        GlobalSecondaryIndexes: properties.GlobalSecondaryIndexes,
+        KeySchema: properties.KeySchema,
+        LocalSecondaryIndexes: properties.LocalSecondaryIndexes,
+        OnDemandThroughput:
+          properties.billingMode.type === 'PAY_PER_REQUEST'
+            ? properties.billingMode.settings.OnDemandThroughput
+            : undefined,
+        ProvisionedThroughput:
+          properties.billingMode.type === 'PROVISIONED'
+            ? properties.billingMode.settings.ProvisionedThroughput
+            : undefined,
+        StreamSpecification: properties.StreamSpecification
+          ? { StreamEnabled: true, StreamViewType: properties.StreamSpecification.StreamViewType }
+          : undefined,
+        TableClass: properties.TableClass,
+        TableName: properties.TableName,
+        Tags: Object.keys(tags).length > 0 ? Object.entries(tags).map(([Key, Value]) => ({ Key, Value })) : undefined,
+        WarmThroughput:
+          properties.billingMode.type === 'PAY_PER_REQUEST'
+            ? properties.billingMode.settings.WarmThroughput
+            : undefined,
+      }),
+    );
+
+    // Wait for DynamoDB table to exist.
+    this.log('Waiting for DynamoDB Table to exist.');
+    await waitUntilTableExists({ client: dynamoDBClient, maxWaitTime: 600 }, { TableName: properties.TableName });
+
+    // Enable TTL if specified.
+    if (properties.timeToLiveAttribute) {
+      await dynamoDBClient.send(
+        new UpdateTimeToLiveCommand({
+          TableName: properties.TableName,
+          TimeToLiveSpecification: {
+            AttributeName: properties.timeToLiveAttribute,
+            Enabled: true,
+          },
+        }),
+      );
+    }
+
+    const tableDescription = createTableCommandOutput.TableDescription!;
+    return {
+      LatestStreamArn: tableDescription.LatestStreamArn,
+      TableArn: tableDescription.TableArn!,
+      TableId: tableDescription.TableId!,
+    };
+  }
+
+  async mock(diff: Diff<DynamoDB>, capture: Partial<DynamoDBSchema['response']>): Promise<DynamoDBSchema['response']> {
+    // Get properties.
+    const table = diff.node;
+    const properties = table.properties;
+
+    return {
+      LatestStreamArn: capture.LatestStreamArn,
+      TableArn:
+        capture.TableArn ??
+        `arn:aws:dynamodb:${properties.awsRegionId}:${properties.awsAccountId}:table/${properties.TableName}`,
+      TableId: capture.TableId,
+    };
+  }
+}
+
+/**
+ * @internal
+ */
+@Factory<AddDynamoDBResourceAction>(AddDynamoDBResourceAction)
+export class AddDynamoDBResourceActionFactory {
+  private static instance: AddDynamoDBResourceAction;
+
+  static async create(): Promise<AddDynamoDBResourceAction> {
+    if (!this.instance) {
+      this.instance = new AddDynamoDBResourceAction();
+    }
+    return this.instance;
+  }
+}

--- a/packages/octo-aws-cdk/src/resources/dynamodb/actions/delete-dynamodb.resource.action.ts
+++ b/packages/octo-aws-cdk/src/resources/dynamodb/actions/delete-dynamodb.resource.action.ts
@@ -1,0 +1,57 @@
+import { DeleteTableCommand, DynamoDBClient, waitUntilTableNotExists } from '@aws-sdk/client-dynamodb';
+import { ANodeAction, Action, type Diff, DiffAction, Factory, type IResourceAction, hasNodeName } from '@quadnix/octo';
+import { DynamoDBClientFactory } from '../../../factories/aws-client.factory.js';
+import { DynamoDB } from '../dynamodb.resource.js';
+
+/**
+ * @internal
+ */
+@Action(DynamoDB)
+export class DeleteDynamoDBResourceAction extends ANodeAction implements IResourceAction<DynamoDB> {
+  constructor() {
+    super();
+  }
+
+  filter(diff: Diff): boolean {
+    return (
+      diff.action === DiffAction.DELETE &&
+      diff.node instanceof DynamoDB &&
+      hasNodeName(diff.node, 'dynamodb') &&
+      diff.field === 'resourceId'
+    );
+  }
+
+  async handle(diff: Diff<DynamoDB>): Promise<void> {
+    // Get properties.
+    const dynamoDB = diff.node;
+    const properties = dynamoDB.properties;
+
+    // Get instances.
+    const dynamoDBClient = await this.container.get<DynamoDBClient, typeof DynamoDBClientFactory>(DynamoDBClient, {
+      args: [properties.awsAccountId, properties.awsRegionId],
+      metadata: { package: '@octo' },
+    });
+
+    // Delete DynamoDB table.
+    await dynamoDBClient.send(new DeleteTableCommand({ TableName: properties.TableName }));
+
+    // Wait for DynamoDB table to be deleted.
+    this.log('Waiting for DynamoDB Table to be deleted.');
+    await waitUntilTableNotExists({ client: dynamoDBClient, maxWaitTime: 600 }, { TableName: properties.TableName });
+  }
+}
+
+/**
+ * @internal
+ */
+@Factory<DeleteDynamoDBResourceAction>(DeleteDynamoDBResourceAction)
+export class DeleteDynamoDBResourceActionFactory {
+  private static instance: DeleteDynamoDBResourceAction;
+
+  static async create(): Promise<DeleteDynamoDBResourceAction> {
+    if (!this.instance) {
+      this.instance = new DeleteDynamoDBResourceAction();
+    }
+    return this.instance;
+  }
+}

--- a/packages/octo-aws-cdk/src/resources/dynamodb/actions/update-dynamodb-tags.resource.action.ts
+++ b/packages/octo-aws-cdk/src/resources/dynamodb/actions/update-dynamodb-tags.resource.action.ts
@@ -1,0 +1,52 @@
+import {
+  Action,
+  Container,
+  type Diff,
+  type DiffValueTypeTagUpdate,
+  Factory,
+  type IResourceAction,
+} from '@quadnix/octo';
+import { GenericResourceTaggingAction } from '../../../utilities/actions/generic-resource-tagging.action.js';
+import { DynamoDB } from '../dynamodb.resource.js';
+
+/**
+ * @internal
+ */
+@Action(DynamoDB)
+export class UpdateDynamoDBTagsResourceAction
+  extends GenericResourceTaggingAction
+  implements IResourceAction<DynamoDB>
+{
+  constructor(container: Container) {
+    super(container);
+  }
+
+  override filter(diff: Diff): boolean {
+    return super.filter(diff);
+  }
+
+  override async handle(diff: Diff<DynamoDB, DiffValueTypeTagUpdate>): Promise<void> {
+    // Get properties.
+    const dynamoDB = diff.node;
+    const properties = dynamoDB.properties;
+    const response = dynamoDB.response;
+
+    await super.handle(diff, { ...properties, resourceArn: response.TableArn! });
+  }
+}
+
+/**
+ * @internal
+ */
+@Factory<UpdateDynamoDBTagsResourceAction>(UpdateDynamoDBTagsResourceAction)
+export class UpdateDynamoDBTagsResourceActionFactory {
+  private static instance: UpdateDynamoDBTagsResourceAction;
+
+  static async create(): Promise<UpdateDynamoDBTagsResourceAction> {
+    if (!this.instance) {
+      const container = Container.getInstance();
+      this.instance = new UpdateDynamoDBTagsResourceAction(container);
+    }
+    return this.instance;
+  }
+}

--- a/packages/octo-aws-cdk/src/resources/dynamodb/actions/update-dynamodb.resource.action.ts
+++ b/packages/octo-aws-cdk/src/resources/dynamodb/actions/update-dynamodb.resource.action.ts
@@ -1,0 +1,202 @@
+import {
+  DescribeTableCommand,
+  DescribeTimeToLiveCommand,
+  DynamoDBClient,
+  UpdateTableCommand,
+  UpdateTimeToLiveCommand,
+} from '@aws-sdk/client-dynamodb';
+import {
+  ANodeAction,
+  Action,
+  type Diff,
+  DiffAction,
+  type DiffValueTypePropertyUpdate,
+  Factory,
+  type IResourceAction,
+  hasNodeName,
+} from '@quadnix/octo';
+import { DynamoDBClientFactory } from '../../../factories/aws-client.factory.js';
+import { RetryUtility } from '../../../utilities/retry/retry.utility.js';
+import { DynamoDB, type DynamoDBDiff } from '../dynamodb.resource.js';
+import type { DynamoDBSchema } from '../index.schema.js';
+
+/**
+ * @internal
+ */
+@Action(DynamoDB)
+export class UpdateDynamoDBResourceAction extends ANodeAction implements IResourceAction<DynamoDB> {
+  constructor() {
+    super();
+  }
+
+  filter(diff: Diff<any, DiffValueTypePropertyUpdate>): boolean {
+    return (
+      diff.action === DiffAction.UPDATE &&
+      diff.node instanceof DynamoDB &&
+      hasNodeName(diff.node, 'dynamodb') &&
+      diff.field === 'properties'
+    );
+  }
+
+  async handle(diff: Diff<DynamoDB, DynamoDBDiff>): Promise<DynamoDBSchema['response']> {
+    // Get properties.
+    const dynamoDB = diff.node;
+    const properties = dynamoDB.properties;
+    const response = dynamoDB.response;
+
+    const globalIndexesToAdd = diff.value.GlobalSecondaryIndexDiffs.filter((d) => d.action === 'add');
+    const globalIndexesToDelete = diff.value.GlobalSecondaryIndexDiffs.filter((d) => d.action === 'delete');
+
+    // Get instances.
+    const dynamoDBClient = await this.container.get<DynamoDBClient, typeof DynamoDBClientFactory>(DynamoDBClient, {
+      args: [properties.awsAccountId, properties.awsRegionId],
+      metadata: { package: '@octo' },
+    });
+
+    // Apply current billing and stream configuration in a single UpdateTable call.
+    await dynamoDBClient.send(
+      new UpdateTableCommand({
+        AttributeDefinitions: properties.AttributeDefinitions,
+        BillingMode: properties.billingMode.type,
+        DeletionProtectionEnabled: properties.DeletionProtectionEnabled,
+        GlobalSecondaryIndexUpdates: [
+          ...(globalIndexesToDelete.length > 0
+            ? globalIndexesToDelete.map((i) => ({
+                Delete: { IndexName: i.properties.IndexName },
+              }))
+            : []),
+          ...(globalIndexesToAdd.length > 0
+            ? globalIndexesToAdd.map((i) => ({
+                Create: {
+                  IndexName: i.properties.IndexName,
+                  KeySchema: i.properties.KeySchema,
+                  OnDemandThroughput:
+                    properties.billingMode.type === 'PAY_PER_REQUEST'
+                      ? properties.billingMode.settings.OnDemandThroughput
+                      : undefined,
+                  Projection: i.properties.Projection,
+                  ProvisionedThroughput:
+                    properties.billingMode.type === 'PROVISIONED'
+                      ? properties.billingMode.settings.ProvisionedThroughput
+                      : undefined,
+                  WarmThroughput:
+                    properties.billingMode.type === 'PAY_PER_REQUEST'
+                      ? properties.billingMode.settings.WarmThroughput
+                      : undefined,
+                },
+              }))
+            : []),
+        ],
+        OnDemandThroughput:
+          properties.billingMode.type === 'PAY_PER_REQUEST'
+            ? properties.billingMode.settings.OnDemandThroughput
+            : undefined,
+        ProvisionedThroughput:
+          properties.billingMode.type === 'PROVISIONED'
+            ? properties.billingMode.settings.ProvisionedThroughput
+            : undefined,
+        StreamSpecification: properties.StreamSpecification
+          ? { StreamEnabled: true, StreamViewType: properties.StreamSpecification.StreamViewType }
+          : { StreamEnabled: false },
+        TableName: properties.TableName,
+        WarmThroughput:
+          properties.billingMode.type === 'PAY_PER_REQUEST'
+            ? properties.billingMode.settings.WarmThroughput
+            : undefined,
+      }),
+    );
+
+    // Enable TTL if specified.
+    if (properties.timeToLiveAttribute) {
+      await dynamoDBClient.send(
+        new UpdateTimeToLiveCommand({
+          TableName: properties.TableName,
+          TimeToLiveSpecification: {
+            AttributeName: properties.timeToLiveAttribute,
+            Enabled: true,
+          },
+        }),
+      );
+    } else {
+      // timeToLiveAttribute was removed — disable TTL using the attribute name currently in AWS.
+      const { TimeToLiveDescription } = await dynamoDBClient.send(
+        new DescribeTimeToLiveCommand({ TableName: properties.TableName }),
+      );
+      if (TimeToLiveDescription?.AttributeName) {
+        await dynamoDBClient.send(
+          new UpdateTimeToLiveCommand({
+            TableName: properties.TableName,
+            TimeToLiveSpecification: {
+              AttributeName: TimeToLiveDescription.AttributeName,
+              Enabled: false,
+            },
+          }),
+        );
+      }
+    }
+
+    // Wait for DynamoDB table and all GSIs to be ACTIVE.
+    await RetryUtility.retryPromise(
+      async (): Promise<boolean> => {
+        this.log('Waiting for DynamoDB table and all GSIs to be ACTIVE.');
+        const { Table } = await dynamoDBClient.send(new DescribeTableCommand({ TableName: properties.TableName }));
+        const isTableActive = Table?.TableStatus === 'ACTIVE';
+        const isAllGSIActive = (Table?.GlobalSecondaryIndexes ?? []).every((i) => i.IndexStatus === 'ACTIVE');
+        return isTableActive && isAllGSIActive;
+      },
+      {
+        initialDelayInMs: 5000,
+        maxRetries: 6,
+        retryDelayInMs: 20000,
+        throwOnError: false,
+      },
+    );
+
+    // Fetch the updated stream ARN when streams are enabled.
+    if (properties.StreamSpecification) {
+      const { Table } = await dynamoDBClient.send(new DescribeTableCommand({ TableName: properties.TableName }));
+      return { ...response, LatestStreamArn: Table?.LatestStreamArn };
+    }
+
+    return { ...response, LatestStreamArn: undefined };
+  }
+
+  async mock(diff: Diff<DynamoDB>, capture: Partial<DynamoDBSchema['response']>): Promise<DynamoDBSchema['response']> {
+    const dynamoDB = diff.node;
+    const properties = dynamoDB.properties;
+    const response = dynamoDB.response;
+
+    if (properties.StreamSpecification) {
+      return {
+        LatestStreamArn: capture.LatestStreamArn,
+        TableArn:
+          capture.TableArn ??
+          `arn:aws:dynamodb:${properties.awsRegionId}:${properties.awsAccountId}:table/${properties.TableName}`,
+        TableId: capture.TableId,
+      };
+    }
+
+    return {
+      LatestStreamArn: undefined,
+      TableArn:
+        capture.TableArn ??
+        `arn:aws:dynamodb:${properties.awsRegionId}:${properties.awsAccountId}:table/${properties.TableName}`,
+      TableId: capture.TableId,
+    };
+  }
+}
+
+/**
+ * @internal
+ */
+@Factory<UpdateDynamoDBResourceAction>(UpdateDynamoDBResourceAction)
+export class UpdateDynamoDBResourceActionFactory {
+  private static instance: UpdateDynamoDBResourceAction;
+
+  static async create(): Promise<UpdateDynamoDBResourceAction> {
+    if (!this.instance) {
+      this.instance = new UpdateDynamoDBResourceAction();
+    }
+    return this.instance;
+  }
+}

--- a/packages/octo-aws-cdk/src/resources/dynamodb/actions/validate-dynamodb.resource.action.ts
+++ b/packages/octo-aws-cdk/src/resources/dynamodb/actions/validate-dynamodb.resource.action.ts
@@ -1,0 +1,128 @@
+import { DescribeTableCommand, DescribeTimeToLiveCommand, DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  ANodeAction,
+  Action,
+  type Diff,
+  DiffAction,
+  Factory,
+  type IResourceAction,
+  TransactionError,
+  hasNodeName,
+} from '@quadnix/octo';
+import { DynamoDBClientFactory } from '../../../factories/aws-client.factory.js';
+import { DynamoDB } from '../dynamodb.resource.js';
+
+/**
+ * @internal
+ */
+@Action(DynamoDB)
+export class ValidateDynamoDBResourceAction extends ANodeAction implements IResourceAction<DynamoDB> {
+  constructor() {
+    super();
+  }
+
+  filter(diff: Diff): boolean {
+    return (
+      diff.action === DiffAction.VALIDATE &&
+      diff.node instanceof DynamoDB &&
+      hasNodeName(diff.node, 'dynamodb') &&
+      diff.field === 'resourceId'
+    );
+  }
+
+  async handle(diff: Diff<DynamoDB>): Promise<void> {
+    // Get properties.
+    const dynamoDB = diff.node;
+    const properties = dynamoDB.properties;
+    const response = dynamoDB.response;
+
+    // Get instances.
+    const dynamoDBClient = await this.container.get<DynamoDBClient, typeof DynamoDBClientFactory>(DynamoDBClient, {
+      args: [properties.awsAccountId, properties.awsRegionId],
+      metadata: { package: '@octo' },
+    });
+
+    // Verify DynamoDB table exists.
+    const describeTableCommandOutput = await dynamoDBClient.send(
+      new DescribeTableCommand({ TableName: properties.TableName }),
+    );
+    if (!describeTableCommandOutput.Table) {
+      throw new TransactionError(`DynamoDB table "${properties.TableName}" does not exist!`);
+    }
+
+    const actualTable = describeTableCommandOutput.Table;
+
+    // Validate DynamoDB table ARN.
+    if (actualTable.TableArn !== response.TableArn) {
+      throw new TransactionError(
+        `DynamoDB table ARN mismatch. Expected: ${response.TableArn}, Actual: ${actualTable.TableArn}`,
+      );
+    }
+
+    // Validate DynamoDB table ID.
+    if (actualTable.TableId !== response.TableId) {
+      throw new TransactionError(
+        `DynamoDB table ID mismatch. Expected: ${response.TableId}, Actual: ${actualTable.TableId}`,
+      );
+    }
+
+    // Validate billing mode (DynamoDB defaults to PROVISIONED if BillingModeSummary is absent).
+    const actualBillingMode = actualTable.BillingModeSummary?.BillingMode ?? 'PROVISIONED';
+    if (actualBillingMode !== properties.billingMode.type) {
+      throw new TransactionError(
+        `DynamoDB table billing mode mismatch. Expected: ${properties.billingMode.type}, Actual: ${actualBillingMode}`,
+      );
+    }
+
+    // Validate key schema length as a basic sanity check.
+    const actualKeySchemaLength = (actualTable.KeySchema ?? []).length;
+    if (actualKeySchemaLength !== properties.KeySchema.length) {
+      throw new TransactionError(
+        `DynamoDB table key schema length mismatch. Expected: ${properties.KeySchema.length}, Actual: ${actualKeySchemaLength}`,
+      );
+    }
+
+    // Validate DynamoDB table name.
+    if (actualTable.TableName !== properties.TableName) {
+      throw new TransactionError(
+        `DynamoDB table name mismatch. Expected: ${properties.TableName}, Actual: ${actualTable.TableName}`,
+      );
+    }
+
+    // Validate TTL configuration if specified.
+    if (properties.timeToLiveAttribute) {
+      const describeTimeToLiveCommandOutput = await dynamoDBClient.send(
+        new DescribeTimeToLiveCommand({ TableName: properties.TableName }),
+      );
+      const timeToLiveStatus = describeTimeToLiveCommandOutput.TimeToLiveDescription?.TimeToLiveStatus;
+      const timeToLiveAttribute = describeTimeToLiveCommandOutput.TimeToLiveDescription?.AttributeName;
+      const timeToLiveEnabled = timeToLiveStatus === 'ENABLED' || timeToLiveStatus === 'ENABLING';
+
+      if (!timeToLiveEnabled) {
+        throw new TransactionError(
+          `DynamoDB table TTL is not enabled. Expected attribute: ${properties.timeToLiveAttribute}`,
+        );
+      }
+      if (timeToLiveAttribute !== properties.timeToLiveAttribute) {
+        throw new TransactionError(
+          `DynamoDB table TTL attribute name mismatch. Expected: ${properties.timeToLiveAttribute}, Actual: ${timeToLiveAttribute}`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * @internal
+ */
+@Factory<ValidateDynamoDBResourceAction>(ValidateDynamoDBResourceAction)
+export class ValidateDynamoDBResourceActionFactory {
+  private static instance: ValidateDynamoDBResourceAction;
+
+  static async create(): Promise<ValidateDynamoDBResourceAction> {
+    if (!this.instance) {
+      this.instance = new ValidateDynamoDBResourceAction();
+    }
+    return this.instance;
+  }
+}

--- a/packages/octo-aws-cdk/src/resources/dynamodb/dynamodb.resource.ts
+++ b/packages/octo-aws-cdk/src/resources/dynamodb/dynamodb.resource.ts
@@ -1,0 +1,240 @@
+import { AResource, Diff, DiffAction, DiffUtility, Resource, ResourceError } from '@quadnix/octo';
+import { DynamoDBSchema, DynamoDBSecondaryIndexSchema } from './index.schema.js';
+
+export type GlobalSecondaryIndexDiffs = {
+  action: 'add' | 'delete';
+  properties: DynamoDBSecondaryIndexSchema;
+};
+
+export type DynamoDBDiff = {
+  GlobalSecondaryIndexDiffs: GlobalSecondaryIndexDiffs[];
+};
+
+/**
+ * @internal
+ */
+@Resource<DynamoDB>('@octo', 'dynamodb', DynamoDBSchema)
+export class DynamoDB extends AResource<DynamoDBSchema, DynamoDB> {
+  declare properties: DynamoDBSchema['properties'];
+  declare response: DynamoDBSchema['response'];
+
+  constructor(resourceId: string, properties: DynamoDBSchema['properties']) {
+    super(resourceId, properties, []);
+
+    // PROVISIONED billing mode requires ProvisionedThroughput.
+    if (properties.billingMode.type === 'PROVISIONED' && !properties.billingMode.settings.ProvisionedThroughput) {
+      throw new ResourceError(
+        `DynamoDB table "${properties.TableName}" requires ProvisionedThroughput when billingMode is PROVISIONED!`,
+        this,
+      );
+    }
+
+    // KeySchema must have valid HASH and RANGE keys defined.
+    // Since max array length can be 2, having checked for a HASH key automatically verifies the other key.
+    if (properties.KeySchema.filter((s) => s.KeyType === 'HASH').length !== 1) {
+      throw new ResourceError(
+        `DynamoDB table "${properties.TableName}" must have 1 HASH key, and at max one RANGE key!`,
+        this,
+      );
+    }
+
+    // GSIs require StreamSpecification to be present for replication.
+    if (!properties.StreamSpecification) {
+      throw new ResourceError(
+        `DynamoDB table "${properties.TableName}" must have StreamSpecification defined when GSIs are present!`,
+        this,
+      );
+    }
+
+    // GSIs KeySchema must have valid HASH and RANGE keys defined.
+    // Since max array length can be 2, having checked for a HASH key automatically verifies the other key.
+    if (!properties.GlobalSecondaryIndexes.every((i) => i.KeySchema.filter((s) => s.KeyType === 'HASH').length === 1)) {
+      throw new ResourceError(
+        `DynamoDB table "${properties.TableName}" GSIs must have 1 HASH key, and at max one RANGE key!`,
+        this,
+      );
+    }
+
+    // GSI INCLUDE projection requires NonKeyAttributes.
+    if (
+      !properties.GlobalSecondaryIndexes.every((i) =>
+        i.Projection.ProjectionType === 'INCLUDE' ? i.Projection.NonKeyAttributes?.length : true,
+      )
+    ) {
+      throw new ResourceError(
+        `DynamoDB table "${properties.TableName}" GSIs with Projection INCLUDE must specify NonKeyAttribute!`,
+        this,
+      );
+    }
+
+    // GSI NonKeyAttribute length must not exceed 20.
+    if (!properties.GlobalSecondaryIndexes.every((i) => (i.Projection.NonKeyAttributes?.length || 0) <= 20)) {
+      throw new ResourceError(
+        `DynamoDB table "${properties.TableName}" GSIs NonKeyAttribute length must not exceed 20!`,
+        this,
+      );
+    }
+
+    // LSI requires the primary KeySchema to have a RANGE key.
+    if (!properties.KeySchema.some((s) => s.KeyType === 'RANGE')) {
+      throw new ResourceError(
+        `DynamoDB table "${properties.TableName}" must have a RANGE key in KeySchema when defining LSIs!`,
+        this,
+      );
+    }
+
+    // Each LSI must share the primary table's HASH key.
+    const primaryHashKey = properties.KeySchema.find((s) => s.KeyType === 'HASH')!.AttributeName;
+    if (
+      !properties.LocalSecondaryIndexes.every(
+        (i) => i.KeySchema.find((s) => s.KeyType === 'HASH')?.AttributeName === primaryHashKey,
+      )
+    ) {
+      throw new ResourceError(
+        `DynamoDB table "${properties.TableName}" LSIs must share the primary table's HASH key!`,
+        this,
+      );
+    }
+
+    // Each LSI must have a RANGE key.
+    if (!properties.LocalSecondaryIndexes.every((i) => i.KeySchema.some((s) => s.KeyType === 'RANGE'))) {
+      throw new ResourceError(
+        `DynamoDB table "${properties.TableName}" LSI KeySchema must contain exactly one HASH and one RANGE key!`,
+        this,
+      );
+    }
+
+    // LSI INCLUDE projection requires NonKeyAttributes.
+    if (
+      !properties.LocalSecondaryIndexes.every((i) =>
+        i.Projection.ProjectionType === 'INCLUDE' ? i.Projection.NonKeyAttributes?.length : true,
+      )
+    ) {
+      throw new ResourceError(
+        `DynamoDB table "${properties.TableName}" LSIs with Projection INCLUDE must specify NonKeyAttribute!`,
+        this,
+      );
+    }
+
+    // LSI NonKeyAttribute length must not exceed 20.
+    if (!properties.LocalSecondaryIndexes.every((i) => (i.Projection.NonKeyAttributes?.length || 0) <= 20)) {
+      throw new ResourceError(
+        `DynamoDB table "${properties.TableName}" LSIs NonKeyAttribute length must not exceed 20!`,
+        this,
+      );
+    }
+
+    // Ensure unique IndexNames across LSIs and GSIs.
+    const allIndexes = [
+      ...properties.GlobalSecondaryIndexes.map((i) => i.IndexName),
+      ...properties.LocalSecondaryIndexes.map((i) => i.IndexName),
+    ];
+    if (allIndexes.length !== new Set(allIndexes).size) {
+      throw new ResourceError(
+        `DynamoDB table "${properties.TableName}" has duplicate index names across LSIs and GSIs!`,
+        this,
+      );
+    }
+
+    // All attribute names defined in KeySchema, LSIs, or GSIs must appear in AttributeDefinitions.
+    const attributeNamesInSchema = [
+      ...properties.KeySchema.map((s) => s.AttributeName),
+      ...properties.GlobalSecondaryIndexes.flatMap((g) => g.KeySchema.map((s) => s.AttributeName)),
+      ...properties.LocalSecondaryIndexes.flatMap((l) => l.KeySchema.map((s) => s.AttributeName)),
+    ];
+    if (!attributeNamesInSchema.every((n) => properties.AttributeDefinitions.find((d) => d.AttributeName === n))) {
+      throw new ResourceError(
+        `DynamoDB table "${properties.TableName}" AttributeDefinitions is missing AttributeName referenced in KeySchema, LSIs, or GSIs!`,
+        this,
+      );
+    }
+
+    // There shouldn't be an attribute name defined in AttributeDefinitions that is not referenced in any schema.
+    if (properties.AttributeDefinitions.length !== new Set(attributeNamesInSchema).size) {
+      throw new ResourceError(
+        `DynamoDB table "${properties.TableName}" AttributeDefinitions has definitions not referenced in any schema!`,
+        this,
+      );
+    }
+  }
+
+  override async diff(previous: DynamoDB): Promise<Diff[]> {
+    const diffs = await super.diff(previous);
+
+    const globalSecondaryIndexDiffs: GlobalSecondaryIndexDiffs[] = [];
+    const currentGSIs = this.properties.GlobalSecondaryIndexes;
+    const previousGSIs = previous.properties.GlobalSecondaryIndexes;
+    for (const index of previousGSIs) {
+      if (!currentGSIs.find((i) => i.IndexName === index.IndexName)) {
+        globalSecondaryIndexDiffs.push({ action: 'delete', properties: { ...index } });
+      }
+    }
+    for (const index of currentGSIs) {
+      if (!previousGSIs.find((i) => i.IndexName === index.IndexName)) {
+        globalSecondaryIndexDiffs.push({ action: 'add', properties: { ...index } });
+      }
+    }
+    if (globalSecondaryIndexDiffs.filter((d) => d.action === 'add').length > 1) {
+      throw new ResourceError(
+        `DynamoDB table "${this.properties.TableName}" cannot add more than 1 GSI at a time!`,
+        this,
+      );
+    }
+
+    let shouldConsolidateUpdateDiffs = false;
+    for (let i = diffs.length - 1; i >= 0; i--) {
+      if (diffs[i].field === 'properties') {
+        // Consolidate property diffs.
+        shouldConsolidateUpdateDiffs = true;
+        diffs.splice(i, 1);
+      }
+    }
+
+    if (shouldConsolidateUpdateDiffs) {
+      diffs.push(
+        new Diff<DynamoDB, DynamoDBDiff>(this, DiffAction.UPDATE, 'properties', {
+          GlobalSecondaryIndexDiffs: globalSecondaryIndexDiffs,
+        }),
+      );
+    }
+
+    return diffs;
+  }
+
+  override async diffInverse(
+    diff: Diff<DynamoDB>,
+    deReferenceResource: (resourceId: string) => Promise<never>,
+  ): Promise<void> {
+    if (diff.action === DiffAction.UPDATE && diff.field === 'properties') {
+      await this.cloneResourceInPlace(diff.node, deReferenceResource);
+    } else {
+      await super.diffInverse(diff, deReferenceResource);
+    }
+  }
+
+  override async diffProperties(previous: DynamoDB): Promise<Diff[]> {
+    if (
+      !DiffUtility.isObjectDeepEquals(previous.properties, this.properties, [
+        'AttributeDefinitions',
+        'billingMode',
+        'GlobalSecondaryIndexes',
+        'StreamSpecification',
+        'timeToLiveAttribute',
+      ])
+    ) {
+      throw new ResourceError('Cannot update DynamoDB immutable properties once it has been created!', this);
+    }
+
+    // Existing GSIs cannot be updated.
+    const currentGSIs = this.properties.GlobalSecondaryIndexes;
+    const previousGSIs = previous.properties.GlobalSecondaryIndexes;
+    for (const ci of currentGSIs) {
+      const pi = previousGSIs.find((pi) => pi.IndexName === ci.IndexName);
+      if (pi && !DiffUtility.isObjectDeepEquals(ci, pi)) {
+        throw new ResourceError('Cannot update DynamoDB GSIs immutable properties once it has been created!', this);
+      }
+    }
+
+    return super.diffProperties(previous);
+  }
+}

--- a/packages/octo-aws-cdk/src/resources/dynamodb/index.schema.ts
+++ b/packages/octo-aws-cdk/src/resources/dynamodb/index.schema.ts
@@ -1,0 +1,245 @@
+import { BaseResourceSchema, Schema, Validate } from '@quadnix/octo';
+
+export type IDynamoDBBillingTypes = {
+  PAY_PER_REQUEST: DynamoDBBillingPayPerRequestSchema;
+  PROVISIONED: DynamoDBBillingProvisionedSchema;
+};
+
+export class DynamoDBBillingPayPerRequestSchema {
+  @Validate({
+    destruct: (value: DynamoDBBillingPayPerRequestSchema['OnDemandThroughput']): number[] => {
+      return value ? [value.MaxReadRequestUnits, value.MaxWriteRequestUnits] : [];
+    },
+    options: { minLength: 5 },
+  })
+  OnDemandThroughput? = Schema<{
+    MaxReadRequestUnits: number;
+    MaxWriteRequestUnits: number;
+  }>();
+
+  @Validate({
+    destruct: (value: DynamoDBBillingPayPerRequestSchema['WarmThroughput']): number[] => {
+      return value ? [value.ReadUnitsPerSecond, value.WriteUnitsPerSecond] : [];
+    },
+    options: { minLength: 5 },
+  })
+  WarmThroughput? = Schema<{
+    ReadUnitsPerSecond: number;
+    WriteUnitsPerSecond: number;
+  }>();
+}
+
+export class DynamoDBBillingProvisionedSchema {
+  @Validate({
+    destruct: (value: DynamoDBBillingProvisionedSchema['ProvisionedThroughput']): number[] => {
+      return value ? [value.ReadCapacityUnits, value.WriteCapacityUnits] : [];
+    },
+    options: { minLength: 5 },
+  })
+  ProvisionedThroughput? = Schema<{
+    ReadCapacityUnits: number;
+    WriteCapacityUnits: number;
+  }>();
+}
+
+export class DynamoDBKeySchema {
+  @Validate({ options: { minLength: 3 } })
+  AttributeName = Schema<string>();
+
+  @Validate({ options: { regex: /^(HASH|RANGE)$/ } })
+  KeyType = Schema<'HASH' | 'RANGE'>();
+}
+
+export class DynamoDBSecondaryIndexSchema {
+  @Validate({ options: { maxLength: 255, minLength: 3, regex: /^[\w.-]+$/ } })
+  IndexName = Schema<string>();
+
+  @Validate([
+    {
+      // Array length must at least be 1.
+      options: { maxLength: 2, minLength: 1 },
+    },
+    {
+      destruct: (value: DynamoDBSecondaryIndexSchema['KeySchema']): DynamoDBKeySchema[] => value,
+      options: { isSchema: { schema: DynamoDBKeySchema } },
+    },
+  ])
+  KeySchema = Schema<DynamoDBKeySchema[]>();
+
+  @Validate([
+    {
+      // ProjectionType must match enum.
+      destruct: (value: DynamoDBSecondaryIndexSchema['Projection']): string[] => [value.ProjectionType],
+      options: { regex: /^(ALL|INCLUDE|KEYS_ONLY)$/ },
+    },
+    {
+      // NonKeyAttributes must at least be 3 characters.
+      destruct: (value: DynamoDBSecondaryIndexSchema['Projection']): string[] => {
+        return value.NonKeyAttributes ? value.NonKeyAttributes : [];
+      },
+      options: { minLength: 3 },
+    },
+  ])
+  Projection = Schema<{ ProjectionType: 'ALL' | 'INCLUDE' | 'KEYS_ONLY'; NonKeyAttributes?: string[] }>();
+}
+
+/**
+ * The `DynamoDBSchema` class is the schema for the `DynamoDB` resource,
+ * which represents an AWS DynamoDB table.
+ * This resource can create and manage a DynamoDB table using the AWS JavaScript SDK V3 API.
+ * See [official sdk docs](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/dynamodb/).
+ *
+ * @group Resources/DynamoDB
+ *
+ * @hideconstructor
+ *
+ * @overrideProperty parents - This resource has no parents.
+ * @overrideProperty resourceId - The resource id is of format `dynamodb-<table-name>`
+ */
+export class DynamoDBSchema extends BaseResourceSchema {
+  /**
+   * Input properties.
+   * * `properties.awsAccountId` - The AWS account id.
+   * * `properties.awsRegionId` - The AWS region id.
+   * * `properties.AttributeDefinitions` - Attribute definitions for key schema and index key attributes.
+   * * `properties.billingMode` - Billing mode: `PAY_PER_REQUEST` or `PROVISIONED`.
+   * * `properties.DeletionProtectionEnabled` - Flag to enable delete protection.
+   * * `properties.KeySchema` - The primary key schema with one HASH and an optional RANGE key.
+   * * `properties.LocalSecondaryIndexes` - Local secondary indexes.
+   * * `properties.GlobalSecondaryIndexes` - Global secondary indexes.
+   * * `properties.StreamSpecification` - DynamoDB Streams configuration.
+   * * `properties.TableClass` - Type of DynamoDB table.
+   * * `properties.TableName` - The DynamoDB table name.
+   * * `properties.timeToLiveAttribute` - Applies TTL on a number attribute.
+   */
+  @Validate<unknown>([
+    {
+      destruct: (value: DynamoDBSchema['properties']): string[] => [value.awsAccountId, value.awsRegionId],
+      options: { minLength: 1 },
+    },
+    {
+      // AttributeDefinitions AttributeName must at least be 3 characters.
+      destruct: (value: DynamoDBSchema['properties']): string[] =>
+        value.AttributeDefinitions.map((d) => d.AttributeName),
+      options: { minLength: 3 },
+    },
+    {
+      // AttributeDefinitions AttributeType must match enum.
+      destruct: (value: DynamoDBSchema['properties']): string[] =>
+        value.AttributeDefinitions.map((d) => d.AttributeType),
+      options: { regex: /^([BNS])$/ },
+    },
+    {
+      // billingMode settings must match schema.
+      destruct: (value: DynamoDBSchema['properties']): DynamoDBBillingPayPerRequestSchema[] => {
+        return value.billingMode.type === 'PAY_PER_REQUEST' ? [value.billingMode.settings] : [];
+      },
+      options: { isSchema: { schema: DynamoDBBillingPayPerRequestSchema } },
+    },
+    {
+      // billingMode settings must match schema.
+      destruct: (value: DynamoDBSchema['properties']): DynamoDBBillingProvisionedSchema[] => {
+        return value.billingMode.type === 'PROVISIONED' ? [value.billingMode.settings] : [];
+      },
+      options: { isSchema: { schema: DynamoDBBillingProvisionedSchema } },
+    },
+    {
+      // billingMode type must match enum.
+      destruct: (value: DynamoDBSchema['properties']): string[] => [value.billingMode.type],
+      options: { regex: /^(PAY_PER_REQUEST|PROVISIONED)$/ },
+    },
+    {
+      // DeletionProtectionEnabled must match enum.
+      destruct: (value: DynamoDBSchema['properties']): string[] => [String(value.DeletionProtectionEnabled)],
+      options: { regex: /^(false)$/ },
+    },
+    {
+      // GlobalSecondaryIndexes must match schema.
+      destruct: (value: DynamoDBSchema['properties']): DynamoDBSecondaryIndexSchema[] => value.GlobalSecondaryIndexes,
+      options: { isSchema: { schema: DynamoDBSecondaryIndexSchema } },
+    },
+    {
+      // KeySchema must match schema, and array must have valid length.
+      destruct: (value: DynamoDBSchema['properties']): DynamoDBKeySchema[] => value.KeySchema,
+      options: { isSchema: { schema: DynamoDBKeySchema }, maxLength: 2, minLength: 1 },
+    },
+    {
+      // LocalSecondaryIndexes must match schema.
+      destruct: (value: DynamoDBSchema['properties']): DynamoDBSecondaryIndexSchema[] => value.LocalSecondaryIndexes,
+      options: { isSchema: { schema: DynamoDBSecondaryIndexSchema } },
+    },
+    {
+      // StreamSpecification StreamViewType must match enum.
+      destruct: (value: DynamoDBSchema['properties']): string[] => {
+        return value.StreamSpecification ? [value.StreamSpecification.StreamViewType] : [];
+      },
+      options: { regex: /^(KEYS_ONLY|NEW_AND_OLD_IMAGES|NEW_IMAGE|OLD_IMAGE)$/ },
+    },
+    {
+      // TableClass must match enum.
+      destruct: (value: DynamoDBSchema['properties']): string[] => [value.TableClass],
+      options: { regex: /^(STANDARD)$/ },
+    },
+    {
+      // TableName must at least be 3 characters.
+      destruct: (value: DynamoDBSchema['properties']): string[] => [value.TableName],
+      options: { maxLength: 255, minLength: 3, regex: /^[\w.-]+$/ },
+    },
+    {
+      // timeToLiveAttribute must at least be 3 characters.
+      destruct: (value: DynamoDBSchema['properties']): string[] => {
+        return value.timeToLiveAttribute ? [value.timeToLiveAttribute] : [];
+      },
+      options: { minLength: 3 },
+    },
+  ])
+  override properties = Schema<{
+    awsAccountId: string;
+    awsRegionId: string;
+    AttributeDefinitions: { AttributeName: string; AttributeType: 'B' | 'N' | 'S' }[];
+    billingMode: {
+      [K in keyof IDynamoDBBillingTypes]: {
+        settings: IDynamoDBBillingTypes[K];
+        type: K;
+      };
+    }[keyof IDynamoDBBillingTypes];
+    DeletionProtectionEnabled: false;
+    GlobalSecondaryIndexes: DynamoDBSecondaryIndexSchema[];
+    KeySchema: DynamoDBKeySchema[];
+    LocalSecondaryIndexes: DynamoDBSecondaryIndexSchema[];
+    StreamSpecification?: {
+      StreamViewType: 'KEYS_ONLY' | 'NEW_AND_OLD_IMAGES' | 'NEW_IMAGE' | 'OLD_IMAGE';
+    };
+    TableClass: 'STANDARD';
+    TableName: string;
+    timeToLiveAttribute?: string;
+  }>();
+
+  /**
+   * Saved response.
+   * * `response.LatestStreamArn` - The ARN of the latest DynamoDB Stream.
+   * * `response.TableArn` - The table ARN.
+   * * `response.TableId` - The unique table ID assigned by AWS.
+   */
+  @Validate({
+    destruct: (value: DynamoDBSchema['response']): string[] => {
+      const subjects: string[] = [];
+      if (value.LatestStreamArn) {
+        subjects.push(value.LatestStreamArn);
+      }
+      if (value.TableArn) {
+        subjects.push(value.TableArn);
+      }
+      if (value.TableId) {
+        subjects.push(value.TableId);
+      }
+      return subjects;
+    },
+    options: { minLength: 1 },
+  })
+  override response = Schema<{
+    LatestStreamArn?: string;
+    TableArn?: string;
+    TableId?: string;
+  }>();
+}

--- a/packages/octo-aws-cdk/src/resources/dynamodb/index.ts
+++ b/packages/octo-aws-cdk/src/resources/dynamodb/index.ts
@@ -1,0 +1,7 @@
+import './actions/add-dynamodb.resource.action.js';
+import './actions/delete-dynamodb.resource.action.js';
+import './actions/update-dynamodb.resource.action.js';
+import './actions/update-dynamodb-tags.resource.action.js';
+import './actions/validate-dynamodb.resource.action.js';
+
+export { DynamoDB } from './dynamodb.resource.js';

--- a/packages/octo-aws-cdk/src/resources/iam-role/actions/update-iam-role-assume-role-policy.resource.action.ts
+++ b/packages/octo-aws-cdk/src/resources/iam-role/actions/update-iam-role-assume-role-policy.resource.action.ts
@@ -23,7 +23,6 @@ export class UpdateIamRoleAssumeRolePolicyResourceAction implements IResourceAct
     // Get properties.
     const iamRole = diff.node;
     const properties = iamRole.properties;
-    const response = iamRole.response;
 
     // Get instances.
     const iamClient = await this.container.get<IAMClient, typeof IAMClientFactory>(IAMClient, {

--- a/packages/octo-aws-cdk/src/resources/s3-storage/s3-storage.resource.ts
+++ b/packages/octo-aws-cdk/src/resources/s3-storage/s3-storage.resource.ts
@@ -72,8 +72,10 @@ export class S3Storage extends AResource<S3StorageSchema, S3Storage> {
   ): Promise<void> {
     if (diff.field === 'update-permissions' && diff.action === DiffAction.UPDATE) {
       // All changes to properties.permissions is in this single diff, invoking one single action.
-      // There is no need to individually clone properties. A single clone is enough.
-      this.clonePropertiesInPlace(diff.node);
+      // Copying all permissions in one shot.
+      this.properties.permissions = JSON.parse(JSON.stringify(this.properties.permissions));
+
+      // There is no need to clone response since it did not change.
     } else {
       await super.diffInverse(diff, deReferenceResource);
     }

--- a/packages/octo-aws-cdk/src/resources/vpc/actions/validate-vpc.resource.action.ts
+++ b/packages/octo-aws-cdk/src/resources/vpc/actions/validate-vpc.resource.action.ts
@@ -88,7 +88,7 @@ export class ValidateVpcResourceAction extends ANodeAction implements IResourceA
     );
     if (dnsHostnamesResult.EnableDnsHostnames?.Value !== true) {
       throw new TransactionError(
-        `VPC DNS hostnames not enabled. Expected: true, Actual: ${dnsHostnamesResult.EnableDnsHostnames?.Value || 'undefined'}`,
+        `VPC DNS hostnames not enabled. Expected: true, Actual: ${dnsHostnamesResult.EnableDnsHostnames?.Value ?? 'undefined'}`,
       );
     }
 
@@ -101,7 +101,7 @@ export class ValidateVpcResourceAction extends ANodeAction implements IResourceA
     );
     if (dnsSupportResult.EnableDnsSupport?.Value !== true) {
       throw new TransactionError(
-        `VPC DNS support not enabled. Expected: true, Actual: ${dnsSupportResult.EnableDnsSupport?.Value || 'undefined'}`,
+        `VPC DNS support not enabled. Expected: true, Actual: ${dnsSupportResult.EnableDnsSupport?.Value ?? 'undefined'}`,
       );
     }
 
@@ -110,6 +110,11 @@ export class ValidateVpcResourceAction extends ANodeAction implements IResourceA
     if (!response.VpcArn!.startsWith(expectedArnPrefix)) {
       throw new TransactionError(
         `VPC ARN region/account mismatch. Expected prefix: ${expectedArnPrefix}, Actual: ${response.VpcArn}`,
+      );
+    }
+    if (!response.VpcArn!.endsWith(response.VpcId!)) {
+      throw new TransactionError(
+        `VPC ARN VpcId suffix mismatch. Expected suffix: ${response.VpcId}, Actual ARN: ${response.VpcArn}`,
       );
     }
   }

--- a/packages/octo-aws-cdk/src/resources/vpc/index.schema.ts
+++ b/packages/octo-aws-cdk/src/resources/vpc/index.schema.ts
@@ -22,16 +22,28 @@ export class VpcSchema extends BaseResourceSchema {
    * * `properties.CidrBlock` - The CIDR block.
    * * `properties.InstanceTenancy` - The instance tenancy. Possible values are `default`.
    */
-  @Validate({
-    destruct: (value: VpcSchema['properties']): string[] => [
-      value.awsAccountId,
-      ...value.awsAvailabilityZones,
-      value.awsRegionId,
-      value.CidrBlock,
-      value.InstanceTenancy,
-    ],
-    options: { minLength: 1 },
-  })
+  @Validate<unknown>([
+    {
+      destruct: (value: VpcSchema['properties']): string[] => [
+        value.awsAccountId,
+        ...value.awsAvailabilityZones,
+        value.awsRegionId,
+        value.CidrBlock,
+        value.InstanceTenancy,
+      ],
+      options: { minLength: 1 },
+    },
+    {
+      // awsAvailabilityZones must have at least one element.
+      destruct: (value: VpcSchema['properties']): string[][] => [value.awsAvailabilityZones],
+      options: { minLength: 1 },
+    },
+    {
+      // CidrBlock must match CIDR notation.
+      destruct: (value: VpcSchema['properties']): string[] => [value.CidrBlock],
+      options: { regex: /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/\d{1,2}$/ },
+    },
+  ])
   override properties = Schema<{
     awsAccountId: string;
     awsAvailabilityZones: string[];

--- a/packages/octo/src/resources/resource.abstract.ts
+++ b/packages/octo/src/resources/resource.abstract.ts
@@ -222,6 +222,9 @@ export abstract class AResource<S extends BaseResourceSchema, T extends UnknownR
       }
       case 'parent': {
         if (diff.action === DiffAction.ADD || diff.action === DiffAction.DELETE) {
+          // Unlike properties, by default we copy all parents in one shot!
+          // If the custom resource wants to apply each parent individually, they must override diffInverse()
+          // with their custom logic.
           await this.cloneResourceInPlace(diff.node as T, deReferenceResource);
         } else if (diff.action === DiffAction.UPDATE) {
           // Do nothing, since the parent of this resource has been updated,


### PR DESCRIPTION
## Summary
Fixes #12, #14, #15, #16.

Four bugs in the `Vpc` resource are addressed in this single PR:

- **#12** (`index.schema.ts`): Added a dedicated `@Validate` entry for `CidrBlock` with a regex (`/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/\d{1,2}$/`) to enforce valid CIDR notation instead of relying solely on the `minLength: 1` check.
- **#14** (`index.schema.ts`): Added an explicit array-length `@Validate` entry for `awsAvailabilityZones` that returns the array itself (not spread) so an empty array is rejected by the `minLength: 1` check.
- **#15** (`validate-vpc.resource.action.ts`): After the existing ARN prefix check, added a check that `response.VpcArn` ends with `response.VpcId` to catch state-file corruption where the prefix matches but the VpcId suffix is wrong.
- **#16** (`validate-vpc.resource.action.ts`): Replaced `||` with `??` in the two DNS boolean error messages so `false` is preserved in the output rather than being coerced to `'undefined'`.

## Test plan
- [ ] `npx nx run @quadnix/octo-aws-cdk:lint` passes with zero warnings
- [ ] `npx nx run @quadnix/octo-aws-cdk:test` passes

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a substantial new AWS resource implementation (DynamoDB) and changes diff-inverse/state-application logic, which could affect reconciliation behavior across resources if edge cases are missed.
> 
> **Overview**
> Adds a new `DynamoDB` resource to `octo-aws-cdk`, including schema, resource diff logic (including GSI add/delete consolidation), and full lifecycle actions (add/delete/update/validate + tags), plus wiring for `DynamoDBClient` creation and package exports/dependencies.
> 
> Fixes and hardens the `Vpc` resource by adding explicit schema validation for non-empty `awsAvailabilityZones` and CIDR formatting, improving validate-action error messages (`??` vs `||`) and adding an ARN suffix sanity check.
> 
> Refines core diff-inverse behavior by cloning full resource state for parent add/delete diffs, adjusts `S3Storage.diffInverse` to deep-copy only permissions for its single update diff, and removes an unused variable in `update-iam-role-assume-role-policy` action. Also updates agent workflow docs and dictionary entries, and refreshes `package-lock.json` for the new AWS SDK dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3574fc0154f7b9b3872faafcaf7b5f2b634cc62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->